### PR TITLE
Update velero 1.2.0 -> 1.3.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,7 +57,7 @@ steps:
     depends_on: [ test-install ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -130,7 +130,7 @@ steps:
     depends_on: [ apply-aws-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -237,7 +237,7 @@ steps:
     depends_on: [ apply-gcp-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -351,7 +351,7 @@ steps:
     depends_on: [ apply-azure-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -483,7 +483,7 @@ steps:
     depends_on: [ test-install ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-115
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -556,7 +556,7 @@ steps:
     depends_on: [ apply-aws-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-115
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -663,7 +663,7 @@ steps:
     depends_on: [ apply-gcp-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-115
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -777,7 +777,7 @@ steps:
     depends_on: [ apply-azure-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-115
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -909,7 +909,7 @@ steps:
     depends_on: [ test-install ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-114
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -982,7 +982,7 @@ steps:
     depends_on: [ apply-aws-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-114
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -1089,7 +1089,7 @@ steps:
     depends_on: [ apply-gcp-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-114
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh
@@ -1203,7 +1203,7 @@ steps:
     depends_on: [ apply-azure-configuration ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-114
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.2.0/velero-v1.2.0-linux-amd64.tar.gz
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.3.1/velero-v1.3.1-linux-amd64.tar.gz
       - tar -zxf velero.tar.gz
       - mv velero*/velero /usr/local/bin/velero
       - bats -t katalog/tests/velero/velero-backup.sh

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -401,7 +401,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -434,7 +434,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -827,7 +827,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -860,7 +860,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -1253,7 +1253,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
     pull: always
     volumes:
     - name: shared
@@ -401,7 +401,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -434,7 +434,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
     pull: always
     volumes:
     - name: shared
@@ -827,7 +827,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -860,7 +860,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
     pull: always
     volumes:
     - name: shared
@@ -1253,7 +1253,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Following packages are included in Fury Kubernetes Disaster Recovery modules:
 | v1.0.0                              |                    |                    |                    |
 | v1.1.0                              |                    |                    |                    |
 | v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 Following packages are included in Fury Kubernetes Disaster Recovery katalog:
 
 - [velero](katalog/velero): Velero (formerly Heptio Ark) gives you tools to
-back up and restore your Kubernetes cluster resources and persistent volumes. Version: **1.2.0**
+back up and restore your Kubernetes cluster resources and persistent volumes. Version: **1.3.1**
 - [velero-restic](katalog/velero/velero-restic): Velero has support for backing up and restoring
-Kubernetes volumes using a free open-source backup tool called restic. Version: **1.2.0**
+Kubernetes volumes using a free open-source backup tool called restic. Version: **1.3.1**
 
 Following packages are included in Fury Kubernetes Disaster Recovery modules:
 

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,26 @@
+# Releases notes
+
+## Changelog
+
+Changes between `1.2.0` and this release: `1.3.0`.
+
+- Update Velero:
+  - Velero from 1.2.0 to 1.3.1
+  - Velero plugins from 1.0.0 to 1.0.1
+
+
+## Upgrade procedure
+
+### From Velero Version v1.2.0
+
+The only needed change is to download the new release, then apply the configuration:
+
+```bash
+$ kustomize build | kubectl apply -f -
+```
+
+
+#### Links
+
+- [Official Velero upgrade guide to 1.2 from 1.3](https://velero.io/docs/v1.3.0/upgrade-to-1.3/)
+

--- a/example/azure-example/main.tf
+++ b/example/azure-example/main.tf
@@ -18,8 +18,8 @@ module "velero" {
   name                       = var.my_cluster_name
   env                        = var.environment
   backup_bucket_name         = "${var.my_cluster_name}-${var.environment}-velero"
-  aks_resource_group_name    = "e2e-testing"
-  velero_resource_group_name = "e2e-testing"
+  aks_resource_group_name    = "sighup-e2e-testing"
+  velero_resource_group_name = "sighup-e2e-testing"
 }
 
 output "cloud_credentials" {

--- a/example/azure-example/main.tf
+++ b/example/azure-example/main.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  version = "=1.44.0"
+}
+
 terraform {
   backend "azurerm" {}
 }

--- a/katalog/velero/README.md
+++ b/katalog/velero/README.md
@@ -148,4 +148,4 @@ bases:
   - katalog/velero/velero-restic
 ```
 
-More information about [Velero Restic integration](https://velero.io/docs/v1.2.0/restic/)
+More information about [Velero Restic integration](https://velero.io/docs/v1.3.1/restic/)

--- a/katalog/velero/velero-aws/kustomization.yaml
+++ b/katalog/velero/velero-aws/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-aws
-    newTag: v1.0.0
+    newTag: v1.0.1
 
 patchesStrategicMerge:
   - plugin-patch.yaml

--- a/katalog/velero/velero-azure/kustomization.yaml
+++ b/katalog/velero/velero-azure/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-microsoft-azure
-    newTag: v1.0.0
+    newTag: v1.0.1
 
 patchesStrategicMerge:
   - plugin-patch.yaml

--- a/katalog/velero/velero-base/kustomization.yaml
+++ b/katalog/velero/velero-base/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 
 images:
   - name: velero/velero
-    newTag: v1.2.0
+    newTag: v1.3.1

--- a/katalog/velero/velero-gcp/kustomization.yaml
+++ b/katalog/velero/velero-gcp/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-gcp
-    newTag: v1.0.0
+    newTag: v1.0.1
 
 patchesStrategicMerge:
   - plugin-patch.yaml

--- a/katalog/velero/velero-on-prem/kustomization.yaml
+++ b/katalog/velero/velero-on-prem/kustomization.yaml
@@ -8,7 +8,7 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-aws
-    newTag: v1.0.0
+    newTag: v1.0.1
 
 patchesStrategicMerge:
   - plugin-patch.yaml

--- a/katalog/velero/velero-restic/README.md
+++ b/katalog/velero/velero-restic/README.md
@@ -7,7 +7,7 @@ case.
 
 ## Image repository and tag
 
-- Velero Restic image: `velero/velero:v1.2.0`
+- Velero Restic image: `velero/velero:v1.3.1`
 - Velero Restic repository: [https://github.com/vmware-tanzu/velero](https://github.com/vmware-tanzu/velero).
 
 

--- a/katalog/velero/velero-restic/kustomization.yaml
+++ b/katalog/velero/velero-restic/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: kube-system
 
 images:
   - name: velero/velero
-    newTag: v1.2.0
+    newTag: v1.3.1
 
 resources:
   - daemonset.yml

--- a/modules/azure-velero/README.md
+++ b/modules/azure-velero/README.md
@@ -3,6 +3,11 @@
 This terraform module provides an easy way to generate Velero required cloud resources (Object Storage and Credentials)
 to backup kubernetes objects and trigger volume snapshots.
 
+## Provider
+
+This module is compatible with `azurerm` terraform provider version:
+[`1.44.0`](https://github.com/terraform-providers/terraform-provider-azurerm/tree/v1.44.0)
+
 ## Inputs
 
 | Name                          | Description                                                                                                      | Type     | Default              | Required |


### PR DESCRIPTION
Whit this PR the velero package inside this module got an update from 1.2.0 to the latest available version (1.3.1).

I will add the release docs ASAP

Pipeline passed: https://ci.sighup.io/sighupio/fury-kubernetes-dr/65/1/1

Thanks