### PR TITLE
Fix typo in azure-velero outputs

### DIFF
--- a/modules/azure-velero/output.tf
+++ b/modules/azure-velero/output.tf
@@ -29,7 +29,7 @@ spec:
   provider: velero.io/azure
   config:
     apiTimeout: 4m0s
-    resouceGroup: ${data.azurerm_resource_group.velero.name}
+    resourceGroup: ${data.azurerm_resource_group.velero.name}
 EOF
 }
 


### PR DESCRIPTION
The aim of this PR is to fix a typo in the `azure-velero` Terraform module output.