### PR TITLE
Updated azure-velero IAM permissions

### DIFF
--- a/modules/azure-velero/iam.tf
+++ b/modules/azure-velero/iam.tf
@@ -33,6 +33,12 @@ resource "azurerm_role_assignment" "aks" {
   principal_id         = azuread_service_principal.main.id
 }
 
+resource "azurerm_role_assignment" "snapshot" {
+  scope                = data.azurerm_resource_group.velero.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.main.id
+}
+
 resource "azurerm_role_assignment" "velero" {
   scope                = azurerm_storage_account.main.id
   role_definition_name = "Contributor"


### PR DESCRIPTION
The aim of this PR is to add `Contributor` role in `velero_resource_group_name` to Velero Service Principal.

Since the generated `VolumeSnapshotLocation` rightfully uses `velero_resource_group_name` as target to save disk snapshots, the Service Principal used by Velero needs to have proper permissions to be able to write to that destination.