### PR TITLE
Add missing namespace in aws-velero outputs

### DIFF
--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -6,10 +6,12 @@ aws_secret_access_key=${aws_iam_access_key.velero_backup.secret}
 EOF
 
   backup_storage_location  = <<EOF
+---
 apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:
   name: default
+  namespace: kube-system
 spec:
   provider: velero.io/aws
   objectStorage:
@@ -18,10 +20,12 @@ spec:
     region: ${var.region}
 EOF
   volume_snapshot_location = <<EOF
+---
 apiVersion: velero.io/v1
 kind: VolumeSnapshotLocation
 metadata:
   name: default
+  namespace: kube-system
 spec:
   provider: velero.io/aws
   config:


### PR DESCRIPTION
`BackupStorageLocation` and `VolumeSnapshotLocation` are namespaced resources: this PR adds the missing namespace in order to deploy them in the same namespace as Velero.