### PR TITLE
Add missing namespace in azure-velero and remove provider block.

### DIFF
--- a/modules/azure-velero/output.tf
+++ b/modules/azure-velero/output.tf
@@ -8,10 +8,12 @@ AZURE_RESOURCE_GROUP=${data.azurerm_resource_group.aks.name}
 AZURE_CLOUD_NAME=${var.azure_cloud_name}
 EOF
   backup_storage_location  = <<EOF
+---
 apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:
   name: default
+  namespace: kube-system
 spec:
   provider: velero.io/azure
   objectStorage:
@@ -21,10 +23,12 @@ spec:
     storageAccount: ${azurerm_storage_account.main.name}
 EOF
   volume_snapshot_location = <<EOF
+---
 apiVersion: velero.io/v1
 kind: VolumeSnapshotLocation
 metadata:
   name: default
+  namespace: kube-system
 spec:
   provider: velero.io/azure
   config:

--- a/modules/azure-velero/velero.tf
+++ b/modules/azure-velero/velero.tf
@@ -1,9 +1,3 @@
-provider "azurerm" {
-  version = "=2.10"
-  features {
-  }
-}
-
 resource "azurerm_storage_account" "main" {
   name                     = "${var.name}${var.env}velero"
   resource_group_name      = data.azurerm_resource_group.velero.name

--- a/modules/azure-velero/versions.tf
+++ b/modules/azure-velero/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    azurerm = ">= 2.10"
+  }
+}


### PR DESCRIPTION
`BackupStorageLocation` and `VolumeSnapshotLocation` are namespaced resources: this PR adds the missing namespace in order to deploy them in the same namespace as Velero.

Furthermore, I've also replaced the internal `provider` block with a version constraint since it's not considered a good practice to include them in child modules as they may conflict with other version constraints declared in the root module. I've also relaxed the version constraint since I've tested the module with version 2.16 of `azurerm` provider.

Refs:
- https://www.terraform.io/docs/configuration/modules.html#providers-within-modules