### PR TITLE
Move cloud credentials from plain text to kubernetes secret (terraform module)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -106,7 +106,7 @@ steps:
       - terraform apply
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -119,7 +119,7 @@ steps:
     depends_on: [ init-aws ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kubectl rollout restart deploy velero -n kube-system
 
@@ -197,7 +197,7 @@ steps:
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
         --var="gcp_project"=$${GCP_PROJECT}
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -210,7 +210,7 @@ steps:
     depends_on: [ init-gcp ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kustomize build katalog/velero/velero-gcp | kubectl apply -f - -n kube-system
       - kubectl rollout restart deploy velero -n kube-system
@@ -296,7 +296,7 @@ steps:
       - terraform apply
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -309,7 +309,7 @@ steps:
     depends_on: [ init-azure ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kustomize build katalog/velero/velero-azure | kubectl apply -f - -n kube-system
       - kubectl rollout restart deploy velero -n kube-system
@@ -492,7 +492,7 @@ steps:
       - terraform apply
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -505,7 +505,7 @@ steps:
     depends_on: [ init-aws ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kubectl rollout restart deploy velero -n kube-system
 
@@ -583,7 +583,7 @@ steps:
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
         --var="gcp_project"=$${GCP_PROJECT}
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -596,7 +596,7 @@ steps:
     depends_on: [ init-gcp ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kustomize build katalog/velero/velero-gcp | kubectl apply -f - -n kube-system
       - kubectl rollout restart deploy velero -n kube-system
@@ -682,7 +682,7 @@ steps:
       - terraform apply
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -695,7 +695,7 @@ steps:
     depends_on: [ init-azure ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kustomize build katalog/velero/velero-azure | kubectl apply -f - -n kube-system
       - kubectl rollout restart deploy velero -n kube-system
@@ -878,7 +878,7 @@ steps:
       - terraform apply
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -891,7 +891,7 @@ steps:
     depends_on: [ init-aws ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-118
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kubectl -n kube-system patch deployment velero -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"date\":\"`date +'%s'`\"}}}}}"
 
@@ -969,7 +969,7 @@ steps:
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
         --var="gcp_project"=$${GCP_PROJECT}
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -982,7 +982,7 @@ steps:
     depends_on: [ init-gcp ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-118
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kustomize build katalog/velero/velero-gcp | kubectl apply -f - -n kube-system
       - kubectl -n kube-system patch deployment velero -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"date\":\"`date +'%s'`\"}}}}}"
@@ -1068,7 +1068,7 @@ steps:
       - terraform apply
         --auto-approve
         --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.config
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
       - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
       - terraform output backup_storage_location > /shared/backup_storage_location.yaml
 
@@ -1081,7 +1081,7 @@ steps:
     depends_on: [ init-azure ]
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-118
-      - kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
       - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
       - kustomize build katalog/velero/velero-azure | kubectl apply -f - -n kube-system
       - kubectl -n kube-system patch deployment velero -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"date\":\"`date +'%s'`\"}}}}}"

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,28 @@
+# Releases notes
+
+## Changelog
+
+Changes between `1.4.0` and this release: `TBD`.
+
+- Change cloud credentials terraform output to be a Kubernetes manifests instead of a plain text file.
+  - Applies to the three different providers *(aws, azure and gcp)*.
+
+## Changes
+
+### Cloud Credentials
+
+Before TBD version, you run commands like:
+
+```bash
+$ terraform output cloud_credentials > /shared/cloud_credentials.config
+$ kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
+secret/cloud-credentials created
+```
+
+Now, to apply the cloud credentials to the cluster:
+
+```bash
+$ terraform output cloud_credentials > /shared/cloud_credentials.yaml
+$ kubectl apply -f /shared/cloud_credentials.yaml
+secret/cloud-credentials created
+```

--- a/example/azure-example/main.tf
+++ b/example/azure-example/main.tf
@@ -2,6 +2,11 @@ terraform {
   backend "azurerm" {}
 }
 
+provider "azurerm" {
+  version = "2.10"
+  features {}
+}
+
 variable "my_cluster_name" {
 
 }

--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -1,7 +1,7 @@
 # AWS Velero
 
 This terraform module provides an easy way to generate Velero required cloud resources (S3 and IAM) to backup
-kubernetes objects and trigger volume snapshot.
+Kubernetes objects and trigger volume snapshots.
 
 ## Inputs
 

--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -1,8 +1,16 @@
 locals {
   cloud_credentials = <<EOF
-[default]
-aws_access_key_id=${aws_iam_access_key.velero_backup.id}
-aws_secret_access_key=${aws_iam_access_key.velero_backup.secret}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-credentials
+  namespace: kube-system
+type: Opaque
+stringData:
+  cloud: |-
+    [default]
+    aws_access_key_id=${aws_iam_access_key.velero_backup.id}
+    aws_secret_access_key=${aws_iam_access_key.velero_backup.secret}
 EOF
 
   backup_storage_location  = <<EOF

--- a/modules/azure-velero/README.md
+++ b/modules/azure-velero/README.md
@@ -1,7 +1,7 @@
 # Azure Velero
 
 This terraform module provides an easy way to generate Velero required cloud resources (Object Storage and Credentials)
-to backup kubernetes objects and trigger volume snapshots.
+to backup Kubernetes objects and trigger volume snapshots.
 
 ## Provider
 

--- a/modules/azure-velero/output.tf
+++ b/modules/azure-velero/output.tf
@@ -1,11 +1,19 @@
 locals {
   cloud_credentials        = <<EOF
-AZURE_SUBSCRIPTION_ID=${data.azurerm_client_config.main.subscription_id}
-AZURE_TENANT_ID=${data.azurerm_client_config.main.tenant_id}
-AZURE_CLIENT_ID=${azuread_service_principal.main.application_id}
-AZURE_CLIENT_SECRET=${azuread_service_principal_password.main.value}
-AZURE_RESOURCE_GROUP=${data.azurerm_resource_group.aks.name}
-AZURE_CLOUD_NAME=${var.azure_cloud_name}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-credentials
+  namespace: kube-system
+type: Opaque
+stringData:
+  cloud: |-
+    AZURE_SUBSCRIPTION_ID=${data.azurerm_client_config.main.subscription_id}
+    AZURE_TENANT_ID=${data.azurerm_client_config.main.tenant_id}
+    AZURE_CLIENT_ID=${azuread_service_principal.main.application_id}
+    AZURE_CLIENT_SECRET=${azuread_service_principal_password.main.value}
+    AZURE_RESOURCE_GROUP=${data.azurerm_resource_group.aks.name}
+    AZURE_CLOUD_NAME=${var.azure_cloud_name}
 EOF
   backup_storage_location  = <<EOF
 ---

--- a/modules/gcp-velero/README.md
+++ b/modules/gcp-velero/README.md
@@ -1,7 +1,7 @@
 # GCP Velero
 
 This terraform module provides an easy way to generate Velero required cloud resources (Bucket and Credentials)
-to backup kubernetes objects and trigger volume snapshots.
+to backup Kubernetes objects and trigger volume snapshots.
 
 ## Inputs
 

--- a/modules/gcp-velero/output.tf
+++ b/modules/gcp-velero/output.tf
@@ -1,6 +1,13 @@
 locals {
   cloud_credentials = <<EOF
-${base64decode(google_service_account_key.velero.private_key)}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-credentials
+  namespace: kube-system
+type: Opaque
+data:
+  cloud: ${google_service_account_key.velero.private_key}
 EOF
 
   backup_storage_location  = <<EOF


### PR DESCRIPTION
Hi team!

This PR aims to solve a bad dev experience (reported by the delivery team). The cloud-credentials output from the terraform modules returned cloud-credentials in plain text.

This PR changes the behaviour to output a Kubernetes Secret ready to apply to the cluster.

Before this PR, you run commands like:

```bash
$ terraform output cloud_credentials > /shared/cloud_credentials.config
$ kubectl create secret generic cloud-credentials --from-file=cloud=/shared/cloud_credentials.config --dry-run -o yaml | kubectl apply -f - -n kube-system
secret/cloud-credentials created
```

Now, to apply the cloud credentials to the cluster:

```bash
$ terraform output cloud_credentials > /shared/cloud_credentials.yaml
$ kubectl apply -f /shared/cloud_credentials.yaml
secret/cloud-credentials created
```

Easy

Tested here: http://ci.sighup.io/sighupio/fury-kubernetes-dr/138/2/1
Thanks!