### PR TITLE
Rename deprecated field

### DIFF
--- a/modules/gcp-velero/gcs.tf
+++ b/modules/gcp-velero/gcs.tf
@@ -6,11 +6,11 @@
 
 # Create a unique GCS bucket per cluster
 resource "google_storage_bucket" "main" {
-  name               = var.backup_bucket_name
-  bucket_policy_only = true
-  project            = var.project
-  location           = "EU"
-  force_destroy      = true
+  name                        = var.backup_bucket_name
+  uniform_bucket_level_access = true
+  project                     = var.project
+  location                    = "EU"
+  force_destroy               = true
   lifecycle {
     prevent_destroy = false
   }


### PR DESCRIPTION
I received this warning after a `terraform plan`: 

```
Warning: "bucket_policy_only": [DEPRECATED] Please use the uniform_bucket_level_access as this field has been renamed by Google.
```

I think it's should be pretty straightforward to fix.
