### PR TITLE
Disabling versioning on velero buckets

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,5 @@
+# Disaster Recovery Core Module version 1.Y.Z
+
+## Changelog
+
+- Removed versioning on AWS S3 bucket

--- a/modules/aws-velero/s3.tf
+++ b/modules/aws-velero/s3.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "backup_bucket" {
   force_destroy = true
 
   versioning {
-    enabled = true
+    enabled = false
   }
 
   server_side_encryption_configuration {

--- a/modules/eks-velero/s3.tf
+++ b/modules/eks-velero/s3.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "backup_bucket" {
   force_destroy = true
 
   versioning {
-    enabled = true
+    enabled = false
   }
 
   server_side_encryption_configuration {


### PR DESCRIPTION
Hi guys, i'm opening this PR because on DR buckets, versioning is not needed.

Object lifecycle is already managed by velero, if we leave versioning enabled the S3 bucket will grow indefinitely.

What do you think?