### PR TITLE
Release 1.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,7 +66,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -90,6 +90,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: test-install
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.2_3.2.2_2.4.1
@@ -405,7 +409,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -425,6 +429,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success
@@ -452,7 +460,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -476,6 +484,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: test-install
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
@@ -791,7 +803,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -811,6 +823,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success
@@ -838,7 +854,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -862,6 +878,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: test-install
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.0_3.3.0_2.4.1
@@ -1177,7 +1197,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -1197,6 +1217,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success
@@ -1223,7 +1247,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -1247,6 +1271,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: test-install
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
@@ -1562,7 +1590,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -1582,6 +1610,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,7 +66,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -405,7 +405,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -452,7 +452,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -791,7 +791,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -838,7 +838,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -1177,7 +1177,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -1223,7 +1223,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -1562,7 +1562,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,398 +41,12 @@ steps:
       - kustomize build katalog/velero/velero-on-prem > velero.yml
 
   - name: deprek8ion
-    image: eu.gcr.io/swade1987/deprek8ion:1.1.31
+    image: eu.gcr.io/swade1987/deprek8ion:1.1.32
     pull: always
     depends_on:
       - render
     commands:
       - /conftest test -p /policies velero.yml
-
----
-kind: pipeline
-name: e2e-kubernetes-1.16
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: cluster-116
-      pipeline_id: cluster-116
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-
-  - name: test-install
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - bats -t katalog/tests/velero/velero-install.sh
-
-  - name: test-backup-restore
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ test-install ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
-      - tar -zxf velero.tar.gz
-      - mv velero*/velero /usr/local/bin/velero
-      - bats -t katalog/tests/velero/velero-backup.sh
-
-  - name: init-aws
-    image: hashicorp/terraform:0.12.16
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ test-backup-restore ]
-    environment:
-      CI_PIPELINE_NUMBER: cluster-116-aws
-      AWS_DEFAULT_REGION:
-        from_secret: aws_region
-      AWS_ACCESS_KEY_ID:
-        from_secret: aws_access_key_id
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: aws_secret_access_key
-      TERRAFORM_TF_STATES_BUCKET_NAME:
-        from_secret: terraform_tf_states_bucket_name
-    commands:
-      - cd example/aws-example
-      - terraform init
-        --backend=true
-        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
-        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
-        --backend-config="region=$${AWS_DEFAULT_REGION}"
-      - terraform apply
-        --auto-approve
-        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
-      - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
-      - terraform output backup_storage_location > /shared/backup_storage_location.yaml
-
-  - name: apply-aws-configuration
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init-aws ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
-      - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
-      - kubectl rollout restart deploy velero -n kube-system
-
-  - name: test-backup-restore-aws
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ apply-aws-configuration ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
-      - tar -zxf velero.tar.gz
-      - mv velero*/velero /usr/local/bin/velero
-      - bats -t katalog/tests/velero/velero-backup.sh
-
-  - name: destroy-aws
-    image: hashicorp/terraform:0.12.16
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ test-backup-restore-aws ]
-    environment:
-      CI_PIPELINE_NUMBER: cluster-116-aws
-      AWS_DEFAULT_REGION:
-        from_secret: aws_region
-      AWS_ACCESS_KEY_ID:
-        from_secret: aws_access_key_id
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: aws_secret_access_key
-      TERRAFORM_TF_STATES_BUCKET_NAME:
-        from_secret: terraform_tf_states_bucket_name
-    commands:
-      - cd example/aws-example
-      - terraform init
-        --backend=true
-        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
-        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
-        --backend-config="region=$${AWS_DEFAULT_REGION}"
-      - terraform destroy
-        --auto-approve
-        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-    when:
-      status:
-      - success
-      - failure
-
-  - name: init-gcp
-    image: hashicorp/terraform:0.12.16
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ test-backup-restore-aws ]
-    environment:
-      GCP_PROJECT:
-        from_secret: gcp_project
-      GCP_CREDENTIALS:
-        from_secret: gcp_credentials
-      GCP_CREDENTIALS_PATH: /shared/terraform-credentials.json
-      CI_PIPELINE_NUMBER: cluster-116-gcp
-      TERRAFORM_TF_STATES_BUCKET_NAME:
-        from_secret: terraform_tf_states_bucket_name
-    commands:
-      - echo $${GCP_CREDENTIALS} > $${GCP_CREDENTIALS_PATH}
-      - export GOOGLE_APPLICATION_CREDENTIALS=$${GCP_CREDENTIALS_PATH}
-      - cd example/gcp-example
-      - terraform init
-        --backend=true
-        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
-        --backend-config="prefix=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
-      - terraform apply
-        --auto-approve
-        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-        --var="gcp_project"=$${GCP_PROJECT}
-      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
-      - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
-      - terraform output backup_storage_location > /shared/backup_storage_location.yaml
-
-  - name: apply-gcp-configuration
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init-gcp ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
-      - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
-      - kustomize build katalog/velero/velero-gcp | kubectl apply -f - -n kube-system
-      - kubectl rollout restart deploy velero -n kube-system
-
-  - name: test-backup-restore-gcp
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ apply-gcp-configuration ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
-      - tar -zxf velero.tar.gz
-      - mv velero*/velero /usr/local/bin/velero
-      - bats -t katalog/tests/velero/velero-backup.sh
-
-  - name: destroy-gcp
-    image: hashicorp/terraform:0.12.16
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ test-backup-restore-gcp ]
-    environment:
-      GCP_PROJECT:
-        from_secret: gcp_project
-      GCP_CREDENTIALS:
-        from_secret: gcp_credentials
-      GCP_CREDENTIALS_PATH: /shared/terraform-credentials.json
-      CI_PIPELINE_NUMBER: cluster-116-gcp
-      TERRAFORM_TF_STATES_BUCKET_NAME:
-        from_secret: terraform_tf_states_bucket_name
-    commands:
-      - cd example/gcp-example
-      - echo $${GCP_CREDENTIALS} > $${GCP_CREDENTIALS_PATH}
-      - export GOOGLE_APPLICATION_CREDENTIALS=$${GCP_CREDENTIALS_PATH}
-      - terraform init
-        --backend=true
-        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
-        --backend-config="prefix=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
-      - terraform destroy
-        --auto-approve
-        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-        --var="gcp_project"=$${GCP_PROJECT}
-    when:
-      status:
-      - success
-      - failure
-
-  - name: init-azure
-    image: hashicorp/terraform:0.12.16
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ test-backup-restore-gcp ]
-    environment:
-      CI_PIPELINE_NUMBER: k8s116azu
-      TERRAFORM_TF_STATES_BUCKET_NAME:
-        from_secret: terraform_tf_states_bucket_name
-      STORAGE_ACCOUNT_NAME:
-        from_secret: storage_account_name
-      RESOURCE_GROUP_NAME:
-        from_secret: resource_group_name
-      ARM_CLIENT_ID:
-        from_secret: arm_client_id
-      ARM_CLIENT_SECRET:
-        from_secret: arm_client_secret
-      ARM_SUBSCRIPTION_ID:
-        from_secret: arm_subscription_id
-      ARM_TENANT_ID:
-        from_secret: arm_tenant_id
-    commands:
-      - cd example/azure-example
-      - terraform init
-        --backend=true
-        --backend-config="storage_account_name=$${STORAGE_ACCOUNT_NAME}"
-        --backend-config="resource_group_name=$${RESOURCE_GROUP_NAME}"
-        --backend-config="container_name=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
-        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
-      - terraform apply
-        --auto-approve
-        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
-      - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
-      - terraform output backup_storage_location > /shared/backup_storage_location.yaml
-
-  - name: apply-azure-configuration
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init-azure ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
-      - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
-      - kustomize build katalog/velero/velero-azure | kubectl apply -f - -n kube-system
-      - kubectl rollout restart deploy velero -n kube-system
-
-  - name: test-backup-restore-azure
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ apply-azure-configuration ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
-      - tar -zxf velero.tar.gz
-      - mv velero*/velero /usr/local/bin/velero
-      - bats -t katalog/tests/velero/velero-backup.sh
-
-  - name: destroy-azure
-    image: hashicorp/terraform:0.12.16
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ test-backup-restore-azure ]
-    environment:
-      CI_PIPELINE_NUMBER: k8s116azu
-      TERRAFORM_TF_STATES_BUCKET_NAME:
-        from_secret: terraform_tf_states_bucket_name
-      STORAGE_ACCOUNT_NAME:
-        from_secret: storage_account_name
-      RESOURCE_GROUP_NAME:
-        from_secret: resource_group_name
-      ARM_CLIENT_ID:
-        from_secret: arm_client_id
-      ARM_CLIENT_SECRET:
-        from_secret: arm_client_secret
-      ARM_SUBSCRIPTION_ID:
-        from_secret: arm_subscription_id
-      ARM_TENANT_ID:
-        from_secret: arm_tenant_id
-    commands:
-      - cd example/azure-example
-      - terraform init
-        --backend=true
-        --backend-config="storage_account_name=$${STORAGE_ACCOUNT_NAME}"
-        --backend-config="resource_group_name=$${RESOURCE_GROUP_NAME}"
-        --backend-config="container_name=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
-        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
-      - terraform destroy
-        --auto-approve
-        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
-    when:
-      status:
-      - success
-      - failure
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
-    pull: always
-    depends_on: [ test-backup-restore-azure ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-116
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
 
 ---
 kind: pipeline
@@ -452,7 +66,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     volumes:
     - name: shared
@@ -791,7 +405,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -838,7 +452,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     volumes:
     - name: shared
@@ -1177,7 +791,7 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
@@ -1224,7 +838,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     volumes:
     - name: shared
@@ -1563,12 +1177,397 @@ steps:
       - failure
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     depends_on: [ test-backup-restore-azure ]
     settings:
       action: destroy
       pipeline_id: cluster-119
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+---
+kind: pipeline
+name: e2e-kubernetes-1.20
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: cluster-120
+      pipeline_id: cluster-120
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+
+  - name: test-install
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - bats -t katalog/tests/velero/velero-install.sh
+
+  - name: test-backup-restore
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ test-install ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
+      - tar -zxf velero.tar.gz
+      - mv velero*/velero /usr/local/bin/velero
+      - bats -t katalog/tests/velero/velero-backup.sh
+
+  - name: init-aws
+    image: hashicorp/terraform:0.12.16
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ test-backup-restore ]
+    environment:
+      CI_PIPELINE_NUMBER: cluster-120-aws
+      AWS_DEFAULT_REGION:
+        from_secret: aws_region
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+      TERRAFORM_TF_STATES_BUCKET_NAME:
+        from_secret: terraform_tf_states_bucket_name
+    commands:
+      - cd example/aws-example
+      - terraform init
+        --backend=true
+        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
+        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
+        --backend-config="region=$${AWS_DEFAULT_REGION}"
+      - terraform apply
+        --auto-approve
+        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
+      - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
+      - terraform output backup_storage_location > /shared/backup_storage_location.yaml
+
+  - name: apply-aws-configuration
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init-aws ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
+      - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
+      - kubectl rollout restart deploy velero -n kube-system
+
+  - name: test-backup-restore-aws
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ apply-aws-configuration ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
+      - tar -zxf velero.tar.gz
+      - mv velero*/velero /usr/local/bin/velero
+      - bats -t katalog/tests/velero/velero-backup.sh
+
+  - name: destroy-aws
+    image: hashicorp/terraform:0.12.16
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ test-backup-restore-aws ]
+    environment:
+      CI_PIPELINE_NUMBER: cluster-120-aws
+      AWS_DEFAULT_REGION:
+        from_secret: aws_region
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+      TERRAFORM_TF_STATES_BUCKET_NAME:
+        from_secret: terraform_tf_states_bucket_name
+    commands:
+      - cd example/aws-example
+      - terraform init
+        --backend=true
+        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
+        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
+        --backend-config="region=$${AWS_DEFAULT_REGION}"
+      - terraform destroy
+        --auto-approve
+        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
+    when:
+      status:
+      - success
+      - failure
+
+  - name: init-gcp
+    image: hashicorp/terraform:0.12.16
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ test-backup-restore-aws ]
+    environment:
+      GCP_PROJECT:
+        from_secret: gcp_project
+      GCP_CREDENTIALS:
+        from_secret: gcp_credentials
+      GCP_CREDENTIALS_PATH: /shared/terraform-credentials.json
+      CI_PIPELINE_NUMBER: cluster-120-gcp
+      TERRAFORM_TF_STATES_BUCKET_NAME:
+        from_secret: terraform_tf_states_bucket_name
+    commands:
+      - echo $${GCP_CREDENTIALS} > $${GCP_CREDENTIALS_PATH}
+      - export GOOGLE_APPLICATION_CREDENTIALS=$${GCP_CREDENTIALS_PATH}
+      - cd example/gcp-example
+      - terraform init
+        --backend=true
+        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
+        --backend-config="prefix=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
+      - terraform apply
+        --auto-approve
+        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
+        --var="gcp_project"=$${GCP_PROJECT}
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
+      - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
+      - terraform output backup_storage_location > /shared/backup_storage_location.yaml
+
+  - name: apply-gcp-configuration
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init-gcp ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
+      - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
+      - kustomize build katalog/velero/velero-gcp | kubectl apply -f - -n kube-system
+      - kubectl rollout restart deploy velero -n kube-system
+
+  - name: test-backup-restore-gcp
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ apply-gcp-configuration ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
+      - tar -zxf velero.tar.gz
+      - mv velero*/velero /usr/local/bin/velero
+      - bats -t katalog/tests/velero/velero-backup.sh
+
+  - name: destroy-gcp
+    image: hashicorp/terraform:0.12.16
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ test-backup-restore-gcp ]
+    environment:
+      GCP_PROJECT:
+        from_secret: gcp_project
+      GCP_CREDENTIALS:
+        from_secret: gcp_credentials
+      GCP_CREDENTIALS_PATH: /shared/terraform-credentials.json
+      CI_PIPELINE_NUMBER: cluster-120-gcp
+      TERRAFORM_TF_STATES_BUCKET_NAME:
+        from_secret: terraform_tf_states_bucket_name
+    commands:
+      - cd example/gcp-example
+      - echo $${GCP_CREDENTIALS} > $${GCP_CREDENTIALS_PATH}
+      - export GOOGLE_APPLICATION_CREDENTIALS=$${GCP_CREDENTIALS_PATH}
+      - terraform init
+        --backend=true
+        --backend-config="bucket=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
+        --backend-config="prefix=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
+      - terraform destroy
+        --auto-approve
+        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
+        --var="gcp_project"=$${GCP_PROJECT}
+    when:
+      status:
+      - success
+      - failure
+
+  - name: init-azure
+    image: hashicorp/terraform:0.12.16
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ test-backup-restore-gcp ]
+    environment:
+      CI_PIPELINE_NUMBER: k8s120azu
+      TERRAFORM_TF_STATES_BUCKET_NAME:
+        from_secret: terraform_tf_states_bucket_name
+      STORAGE_ACCOUNT_NAME:
+        from_secret: storage_account_name
+      RESOURCE_GROUP_NAME:
+        from_secret: resource_group_name
+      ARM_CLIENT_ID:
+        from_secret: arm_client_id
+      ARM_CLIENT_SECRET:
+        from_secret: arm_client_secret
+      ARM_SUBSCRIPTION_ID:
+        from_secret: arm_subscription_id
+      ARM_TENANT_ID:
+        from_secret: arm_tenant_id
+    commands:
+      - cd example/azure-example
+      - terraform init
+        --backend=true
+        --backend-config="storage_account_name=$${STORAGE_ACCOUNT_NAME}"
+        --backend-config="resource_group_name=$${RESOURCE_GROUP_NAME}"
+        --backend-config="container_name=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
+        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
+      - terraform apply
+        --auto-approve
+        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
+      - terraform output cloud_credentials > /shared/cloud_credentials.yaml
+      - terraform output volume_snapshot_location > /shared/volume_snapshot_location.yaml
+      - terraform output backup_storage_location > /shared/backup_storage_location.yaml
+
+  - name: apply-azure-configuration
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init-azure ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - kubectl apply -f /shared/cloud_credentials.yaml -n kube-system
+      - kubectl apply -f /shared/backup_storage_location.yaml -n kube-system
+      - kustomize build katalog/velero/velero-azure | kubectl apply -f - -n kube-system
+      - kubectl rollout restart deploy velero -n kube-system
+
+  - name: test-backup-restore-azure
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ apply-azure-configuration ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - curl -Ls -o velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz
+      - tar -zxf velero.tar.gz
+      - mv velero*/velero /usr/local/bin/velero
+      - bats -t katalog/tests/velero/velero-backup.sh
+
+  - name: destroy-azure
+    image: hashicorp/terraform:0.12.16
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ test-backup-restore-azure ]
+    environment:
+      CI_PIPELINE_NUMBER: k8s120azu
+      TERRAFORM_TF_STATES_BUCKET_NAME:
+        from_secret: terraform_tf_states_bucket_name
+      STORAGE_ACCOUNT_NAME:
+        from_secret: storage_account_name
+      RESOURCE_GROUP_NAME:
+        from_secret: resource_group_name
+      ARM_CLIENT_ID:
+        from_secret: arm_client_id
+      ARM_CLIENT_SECRET:
+        from_secret: arm_client_secret
+      ARM_SUBSCRIPTION_ID:
+        from_secret: arm_subscription_id
+      ARM_TENANT_ID:
+        from_secret: arm_tenant_id
+    commands:
+      - cd example/azure-example
+      - terraform init
+        --backend=true
+        --backend-config="storage_account_name=$${STORAGE_ACCOUNT_NAME}"
+        --backend-config="resource_group_name=$${RESOURCE_GROUP_NAME}"
+        --backend-config="container_name=$${TERRAFORM_TF_STATES_BUCKET_NAME}"
+        --backend-config="key=${CI_REPO}/${DRONE_BRANCH}/${CI_BUILD_NUMBER}/$${CI_PIPELINE_NUMBER}"
+      - terraform destroy
+        --auto-approve
+        --var="my_cluster_name=$${CI_PIPELINE_NUMBER}"
+    when:
+      status:
+      - success
+      - failure
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    pull: always
+    depends_on: [ test-backup-restore-azure ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-120
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:
@@ -1597,9 +1596,9 @@ kind: pipeline
 name: release
 
 depends_on:
-  - e2e-kubernetes-1.16
   - e2e-kubernetes-1.17
   - e2e-kubernetes-1.18
+  - e2e-kubernetes-1.19
 
 platform:
   os: linux

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The following packages are included in Fury Kubernetes Disaster Recovery katalog:
 
-- [velero](katalog/velero): Velero (formerly Heptio Ark) gives you tools to
+- [velero](katalog/velero): Velero (formerly Heptio Ark) gives you a tool to
 back up and restore your Kubernetes cluster resources and persistent volumes. Version: **1.5.2**
 - [velero-restic](katalog/velero/velero-restic): Velero has support for backing up and restoring
 Kubernetes volumes using a free open-source backup tool called restic. Version: **1.5.2**
@@ -20,16 +20,17 @@ from an eks cluster.
 
 ## Compatibility
 
-| Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             | 1.17.X             | 1.18.X             | 1.19.X             |
-|-------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
-| v1.0.0                              |                    |                    |                    |                    |                    |                    |
-| v1.1.0                              |                    |                    |                    |                    |                    |                    |
-| v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.3.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.4.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.5.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
-| v1.5.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
+| Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             | 1.17.X             | 1.18.X             | 1.19.X             | 1.20.X             |
+|-------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
+| v1.0.0                              |                    |                    |                    |                    |                    |                    |                    |
+| v1.1.0                              |                    |                    |                    |                    |                    |                    |                    |
+| v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.3.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.4.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
+| v1.5.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |
+| v1.5.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |
+| v1.6.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
 
 - :white_check_mark: Compatible
 - :warning: Has issues
@@ -37,7 +38,7 @@ from an eks cluster.
 
 ### Warning
 
-- :warning: : module version: `v1.5.0` and Kubernetes Version: `1.19.x`. It works as expected. Marked as warning
+- :warning: : module version: `v1.6.0` and Kubernetes Version: `1.20.x`. It works as expected. Marked as warning
 because it is not officially supported by [SIGHUP](https://sighup.io).
 
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,5 +1,0 @@
-# Disaster Recovery Core Module version 1.Y.Z
-
-## Changelog
-
-- Removed versioning on AWS S3 bucket

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -1,0 +1,27 @@
+# Disaster Recovery Core Module version 1.6.0
+
+SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
+With the Kubernetes 1.20 release, it became the perfect time to start testing this module against this Kubernetes
+release. Minor works have been done in the AWS terraform module.
+
+Continue reading the [Changelog](#changelog) to discover them:
+
+## Changelog
+
+- Removed versioning on [AWS S3 bucket](../../modules/aws-velero).
+- Kubernetes support:
+  - Deprecate Kubernetes 1.16 support.
+  - Kubernetes 1.19 is considered stable.
+  - Add tech-preview support to Kubernetes 1.20.
+
+## Upgrade path
+
+To upgrade this core module from `v1.5.1`, you need to download this new version, then apply the
+`terraform` project. No further action is required.
+
+```bash
+terraform init
+terraform plan
+# You should see the versioning check modification
+terraform apply
+```

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -13,6 +13,7 @@ Continue reading the [Changelog](#changelog) to discover them:
   - Deprecate Kubernetes 1.16 support.
   - Kubernetes 1.19 is considered stable.
   - Add tech-preview support to Kubernetes 1.20.
+- All the container images come from the SIGHUP registry to avoid rate limits.
 
 ## Upgrade path
 

--- a/katalog/velero/README.md
+++ b/katalog/velero/README.md
@@ -5,7 +5,7 @@
 - [Velero](#velero)
   - [Requirements](#requirements)
   - [Server deployment](#server-deployment)
-    - [Velero on premises](#velero-on-premises)
+    - [Velero on-premises](#velero-on-premises)
     - [Velero in AWS](#velero-in-aws)
     - [Velero in GCP](#velero-in-gcp)
     - [Velero in Azure](#velero-in-azure)
@@ -14,7 +14,7 @@
 
 ___
 
-Velero *(formerly Heptio Ark)* gives you tools to back up and restore your Kubernetes cluster resources and persistent
+Velero *(formerly Heptio Ark)* gives you tool to back up and restore your Kubernetes cluster resources and persistent
 volumes. You can run Velero with a cloud provider or on-premises. Velero lets you:
 
 - Take backups of your cluster and restore in case of loss.
@@ -36,11 +36,11 @@ as this feature deploys [a `ServiceMonitor` definition](velero-base/serviceMonit
 
 ## Server deployment
 
-Every velero deployment, does not matter if on premises or in any of the supported cloud, can configure
-[schedules](#velero-schedule) to backup all cluster manifests and/or cluster persistence volumes.
+Every velero deployment, does not matter if on-premises or in any of the supported cloud, can configure
+[schedules](#velero-schedule) to back up all cluster manifests and/or cluster persistence volumes.
 
 
-### Velero on premises
+### Velero on-premises
 
 The [velero-on-prem](./velero-on-prem/) feature deploys a [MinIO](https://min.io/) instance in the same cluster as
 object storage backend that Velero can use to store backup data.

--- a/katalog/velero/velero-aws/kustomization.yaml
+++ b/katalog/velero/velero-aws/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-aws
+    newName: reg.sighup.io/sighupio/fury/velero/velero-plugin-for-aws
     newTag: v1.1.0
 
 patchesStrategicMerge:

--- a/katalog/velero/velero-azure/kustomization.yaml
+++ b/katalog/velero/velero-azure/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-microsoft-azure
+    newName: reg.sighup.io/sighupio/fury/velero/velero-plugin-for-microsoft-azure
     newTag: v1.1.0
 
 patchesStrategicMerge:

--- a/katalog/velero/velero-base/kustomization.yaml
+++ b/katalog/velero/velero-base/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
 
 images:
   - name: velero/velero
+    newName: reg.sighup.io/sighupio/fury/velero/velero
     newTag: v1.5.2

--- a/katalog/velero/velero-gcp/kustomization.yaml
+++ b/katalog/velero/velero-gcp/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-gcp
+    newName: reg.sighup.io/sighupio/fury/velero/velero-plugin-for-gcp
     newTag: v1.1.0
 
 patchesStrategicMerge:

--- a/katalog/velero/velero-on-prem/kustomization.yaml
+++ b/katalog/velero/velero-on-prem/kustomization.yaml
@@ -12,7 +12,12 @@ bases:
 
 images:
   - name: velero/velero-plugin-for-aws
+    newName: reg.sighup.io/sighupio/fury/velero/velero-plugin-for-aws
     newTag: v1.1.0
+  - name: groundnuty/k8s-wait-for
+    newName: reg.sighup.io/sighupio/fury/groundnuty/k8s-wait-for
+    newTag: v1.2
+
 
 patchesStrategicMerge:
   - plugin-patch.yaml

--- a/katalog/velero/velero-on-prem/minio/kustomization.yaml
+++ b/katalog/velero/velero-on-prem/minio/kustomization.yaml
@@ -42,9 +42,14 @@ vars:
 
 images:
   - name: minio/minio
+    newName: reg.sighup.io/sighupio/fury/minio
     newTag: RELEASE.2020-09-17T04-49-20Z
   - name: minio/mc
+    newName: reg.sighup.io/sighupio/fury/minio/mc
     newTag: RELEASE.2020-09-03T00-08-28Z
+  - name: groundnuty/k8s-wait-for
+    newName: reg.sighup.io/sighupio/fury/groundnuty/k8s-wait-for
+    newTag: v1.2
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/katalog/velero/velero-on-prem/minio/sts.yaml
+++ b/katalog/velero/velero-on-prem/minio/sts.yaml
@@ -28,7 +28,7 @@ spec:
         envFrom:
         - secretRef:
             name: minio-credentials
-        image: minio/minio:latests
+        image: minio/minio
         securityContext:
           allowPrivilegeEscalation: false
         args:

--- a/katalog/velero/velero-restic/kustomization.yaml
+++ b/katalog/velero/velero-restic/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: kube-system
 
 images:
   - name: velero/velero
+    newName: reg.sighup.io/sighupio/fury/velero/velero
     newTag: v1.5.2
 
 resources:


### PR DESCRIPTION
Ciao team!

This PR contains an update of the DR module. It has not a lot of changes, minor upgrade.

## Changelog

- Removed versioning on [AWS S3 bucket](../../modules/aws-velero).
- Kubernetes support:
  - Deprecate Kubernetes 1.16 support.
  - Kubernetes 1.19 is considered stable.
  - Add tech-preview support to Kubernetes 1.20.

Pipeline: http://ci.sighup.io/sighupio/fury-kubernetes-dr/177

The upgrade procedure has been tested manually.

Thanks!