### PR TITLE
Disable versioning on velero buckets

### DIFF
--- a/modules/aws-velero/s3.tf
+++ b/modules/aws-velero/s3.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "backup_bucket" {
   force_destroy = true
 
   versioning {
-    enabled = true
+    enabled = false
   }
 
   server_side_encryption_configuration {

--- a/modules/eks-velero/s3.tf
+++ b/modules/eks-velero/s3.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "backup_bucket" {
   force_destroy = true
 
   versioning {
-    enabled = true
+    enabled = false
   }
 
   server_side_encryption_configuration {


### PR DESCRIPTION
Hi all, 
this simple PR avoids using versioning on velero buckets. This is important as backup sizes include disk backups and therefore are not negligible. Moreover, velero takes care of rotating backups making versioning redudant. 