### PR TITLE
Simplify interface of all the terraform modules 

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -4,7 +4,10 @@ This new release simplifies the interface of the current modules.
 
 ## Changelog
 
-- Simplify interface for `dr/eks` module
+- Simplify interface for `eks-velero` module
+- Simplify interface for `aws-velero` module
+- Simplify interface for `gcp-velero` module
+- Simplify interface for `azure-velero` module
 
 ## Upgrade path
 
@@ -96,6 +99,35 @@ module "velero" {
   backup_bucket_name = "my-cluster-staging-velero"
   project            = "sighup-staging"
   tags               = {
+    "my-key": "my-value"
+  }
+}
+```
+
+### modules/azure-velero
+
+Old interface:
+
+```hcl
+module "velero" {
+  source                     = "../vendor/modules/azure-velero"
+  name                       = "sighup"
+  env                        = "production"
+  backup_bucket_name         = "sighup-production-cluster-backup"
+  aks_resource_group_name    = "XXX"
+  velero_resource_group_name = "XXX"
+}
+```
+
+New interface:
+
+```hcl
+module "velero" {
+  source                     = "../vendor/modules/azure-velero"
+  backup_bucket_name         = "sighup-production-cluster-backup"
+  aks_resource_group_name    = "XXX"
+  velero_resource_group_name = "XXX"
+  tags                       = {
     "my-key": "my-value"
   }
 }

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,49 @@
+# Disaster Recovery Core Module version unreleased
+
+This new release simplifies the interface of the current modules.
+
+## Changelog
+
+- Simplify interface for `dr/eks` module
+
+## Upgrade path
+
+Replace the module interface to match the new one.
+
+### dr/eks 
+
+Old interface: 
+
+```hcl
+locals {
+    eks_oidc_issuer = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
+}
+
+module "velero" {
+  source             = "path/to/dr/eks-velero"
+  name               = "my-cluster"
+  env                = "test"
+  backup_bucket_name = "my-cluster-velero"
+  oidc_provider_url  = local.eks_oidc_issuer
+  region             = "eu-west-1"
+}
+```
+
+New interface:
+
+```hcl
+locals {
+    eks_oidc_issuer = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
+}
+
+module "velero" {
+  source             = "path/to/dr/eks-velero"
+  backup_bucket_name = "my-cluster-velero"   
+  oidc_provider_url  = local.eks_oidc_issuer
+  tags               = {
+      "cluster" : "my-cluster",
+      "env"     : "test",
+      "any-key" : "any-value"
+  }
+}
+```

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,7 +20,7 @@ locals {
 }
 
 module "velero" {
-  source             = "path/to/dr/eks-velero"
+  source             = "../vendor/modules/eks-velero"
   name               = "my-cluster"
   env                = "test"
   backup_bucket_name = "my-cluster-velero"
@@ -37,7 +37,7 @@ locals {
 }
 
 module "velero" {
-  source             = "path/to/dr/eks-velero"
+  source             = "../vendor/modules/eks-velero"
   backup_bucket_name = "my-cluster-velero"
   oidc_provider_url  = local.eks_oidc_issuer
   tags               = {
@@ -68,6 +68,33 @@ New interface:
 module "velero" {
   source             = "../vendor/modules/aws-velero"
   backup_bucket_name = "my-cluster-staging-velero"
+  tags               = {
+    "my-key": "my-value"
+  }
+}
+```
+
+### modules/gcp-velero
+
+Old interface:
+
+```hcl
+module "velero" {
+  source             = "../vendor/modules/gcp-velero"
+  name               = "my-cluster"
+  env                = "staging"
+  backup_bucket_name = "my-cluster-staging-velero"
+  project            = "sighup-staging"
+}
+```
+
+New interface:
+
+```hcl
+module "velero" {
+  source             = "../vendor/modules/gcp-velero"
+  backup_bucket_name = "my-cluster-staging-velero"
+  project            = "sighup-staging"
   tags               = {
     "my-key": "my-value"
   }

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,7 +12,7 @@ Replace the module interface to match the new one.
 
 ### modules/eks-velero
 
-Old interface: 
+Old interface:
 
 ```hcl
 locals {
@@ -38,7 +38,7 @@ locals {
 
 module "velero" {
   source             = "path/to/dr/eks-velero"
-  backup_bucket_name = "my-cluster-velero"   
+  backup_bucket_name = "my-cluster-velero"
   oidc_provider_url  = local.eks_oidc_issuer
   tags               = {
       "cluster" : "my-cluster",
@@ -53,7 +53,13 @@ module "velero" {
 Old interface:
 
 ```hcl
-
+module "velero" {
+  source             = "../vendor/modules/aws-velero"
+  name               = "my-cluster"
+  env                = "staging"
+  backup_bucket_name = "my-cluster-staging-velero"
+  region             = "eu-west-1"
+}
 ```
 
 New interface:

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,7 +10,7 @@ This new release simplifies the interface of the current modules.
 
 Replace the module interface to match the new one.
 
-### dr/eks 
+### modules/eks-velero
 
 Old interface: 
 
@@ -44,6 +44,26 @@ module "velero" {
       "cluster" : "my-cluster",
       "env"     : "test",
       "any-key" : "any-value"
+  }
+}
+```
+
+### modules/aws-velero
+
+Old interface:
+
+```hcl
+
+```
+
+New interface:
+
+```hcl
+module "velero" {
+  source             = "../vendor/modules/aws-velero"
+  backup_bucket_name = "my-cluster-staging-velero"
+  tags               = {
+    "my-key": "my-value"
   }
 }
 ```

--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -8,7 +8,7 @@ Kubernetes objects and trigger volume snapshots.
 | Name                 | Description                            | Type          | Default | Required |
 | -------------------- | -------------------------------------- | ------------- | ------- | :------: |
 | backup\_bucket\_name | Backup Bucket Name                     | `string`      | n/a     |   yes    |
-| tags                 | AWS Region where colocate the bucket   | `map(string)` | `{}`    |   no     |
+| tags                 | Custom tags to apply to resources      | `map(string)` | `{}`    |   no     |
 
 ## Outputs
 
@@ -22,8 +22,9 @@ Kubernetes objects and trigger volume snapshots.
 
 ```hcl
 module "velero" {
-  source             = "../vendor/modules/aws-velero"
+  source             = "../vendor/modules/gcp-velero"
   backup_bucket_name = "my-cluster-staging-velero"
+  project            = "sighup-staging"
   tags               = {
     "my-key": "my-value"
   }

--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -5,12 +5,10 @@ Kubernetes objects and trigger volume snapshots.
 
 ## Inputs
 
-| Name                 | Description                          | Type     | Default | Required |
-| -------------------- | ------------------------------------ | -------- | ------- | :------: |
-| backup\_bucket\_name | Backup Bucket Name                   | `string` | n/a     |   yes    |
-| env                  | Environment Name                     | `string` | n/a     |   yes    |
-| name                 | Cluster Name                         | `string` | n/a     |   yes    |
-| region               | AWS Region where colocate the bucket | `string` | n/a     |   yes    |
+| Name                 | Description                            | Type          | Default | Required |
+| -------------------- | -------------------------------------- | ------------- | ------- | :------: |
+| backup\_bucket\_name | Backup Bucket Name                     | `string`      | n/a     |   yes    |
+| tags                 | AWS Region where colocate the bucket   | `map(string)` | `{}`    |   no     |
 
 ## Outputs
 
@@ -25,10 +23,10 @@ Kubernetes objects and trigger volume snapshots.
 ```hcl
 module "velero" {
   source             = "../vendor/modules/aws-velero"
-  name               = "my-cluster"
-  env                = "staging"
   backup_bucket_name = "my-cluster-staging-velero"
-  region             = "eu-west-1"
+  tags               = {
+    "my-key": "my-value"
+  }
 }
 ```
 

--- a/modules/aws-velero/iam.tf
+++ b/modules/aws-velero/iam.tf
@@ -5,12 +5,13 @@
  */
 
 resource "aws_iam_user" "velero_backup_user" {
-  name = "${var.name}-${var.env}-velero-backup"
+  name = "${var.backup_bucket_name}-velero-backup"
   path = "/"
+  tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "velero_backup" {
-  name       = "${var.name}-${var.env}-velero-backup"
+  name       = "${var.backup_bucket_name}-velero-backup"
   users      = [aws_iam_user.velero_backup_user.name]
   policy_arn = aws_iam_policy.velero_backup.arn
 }
@@ -20,7 +21,7 @@ resource "aws_iam_access_key" "velero_backup" {
 }
 
 resource "aws_iam_policy" "velero_backup" {
-  name = "${var.name}-${var.env}-velero-backup"
+  name = "${var.backup_bucket_name}-velero-backup"
 
   policy = <<EOF
 {

--- a/modules/aws-velero/input.tf
+++ b/modules/aws-velero/input.tf
@@ -4,24 +4,15 @@
  * license that can be found in the LICENSE file.
  */
 
-variable "name" {
-  type        = string
-  description = "Cluster Name"
-}
-
-variable "env" {
-  type        = string
-  description = "Environment Name"
-}
-
 variable "backup_bucket_name" {
   type        = string
   description = "Backup Bucket Name"
 }
 
-variable "region" {
-  type        = string
-  description = "AWS Region where colocate the bucket"
+variable "tags" {
+  type        = map(string)
+  description = "Custom tags to apply to resources"
+  default     = {}
 }
 
 data "aws_caller_identity" "current" {}

--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -31,8 +31,9 @@ spec:
   objectStorage:
     bucket: ${aws_s3_bucket.backup_bucket.bucket}
   config:
-    region: ${var.region}
+    region: ${aws_s3_bucket.backup_bucket.region}
 EOF
+
   volume_snapshot_location = <<EOF
 ---
 apiVersion: velero.io/v1
@@ -43,7 +44,7 @@ metadata:
 spec:
   provider: velero.io/aws
   config:
-    region: ${var.region}
+    region: ${aws_s3_bucket.backup_bucket.region}
 EOF
 }
 

--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -19,7 +19,7 @@ stringData:
     aws_secret_access_key=${aws_iam_access_key.velero_backup.secret}
 EOF
 
-  backup_storage_location  = <<EOF
+  backup_storage_location = <<EOF
 ---
 apiVersion: velero.io/v1
 kind: BackupStorageLocation

--- a/modules/aws-velero/s3.tf
+++ b/modules/aws-velero/s3.tf
@@ -21,9 +21,5 @@ resource "aws_s3_bucket" "backup_bucket" {
     }
   }
 
-  tags = {
-    Name        = var.backup_bucket_name
-    ClusterName = var.name
-    Environment = var.env
-  }
+  tags = var.tags
 }

--- a/modules/azure-velero/README.md
+++ b/modules/azure-velero/README.md
@@ -10,14 +10,13 @@ This module is compatible with `azurerm` terraform provider version:
 
 ## Inputs
 
-| Name                          | Description                                                                                                      | Type     | Default              | Required |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | -------------------- | :------: |
-| aks\_resource\_group\_name    | Resource group name of AKS cluster to backup                                                                     | `string` | n/a                  |   yes    |
-| azure\_cloud\_name            | available azure\_cloud\_name values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud | `string` | `"AzurePublicCloud"` |    no    |
-| backup\_bucket\_name          | Backup Bucket Name                                                                                               | `string` | n/a                  |   yes    |
-| env                           | Environment Name                                                                                                 | `string` | n/a                  |   yes    |
-| name                          | Cluster Name                                                                                                     | `string` | n/a                  |   yes    |
-| velero\_resource\_group\_name | Resouce group in which to create velero resources                                                                | `string` | n/a                  |   yes    |
+| Name                          | Description                                                                                                      | Type          | Default              | Required |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------- | -------------------- | :------: |
+| aks\_resource\_group\_name    | Resource group name of AKS cluster to backup                                                                     | `string`      | n/a                  |   yes    |
+| azure\_cloud\_name            | available azure\_cloud\_name values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud | `string`      | `"AzurePublicCloud"` |   no     |
+| backup\_bucket\_name          | Backup Bucket Name                                                                                               | `string`      | n/a                  |   yes    |
+| velero\_resource\_group\_name | Resouce group in which to create velero resources                                                                | `string`      | n/a                  |   yes    |
+| tags                          | Custom tags to apply to resources                                                                                | `map(string)` | `{}`                 |   no     |
 
 ## Outputs
 
@@ -32,11 +31,12 @@ This module is compatible with `azurerm` terraform provider version:
 ```hcl
 module "velero" {
   source                     = "../vendor/modules/azure-velero"
-  name                       = "sighup"
-  env                        = "production"
   backup_bucket_name         = "sighup-production-cluster-backup"
   aks_resource_group_name    = "XXX"
   velero_resource_group_name = "XXX"
+  tags                       = {
+    "my-key": "my-value"
+  }
 }
 ```
 

--- a/modules/azure-velero/iam.tf
+++ b/modules/azure-velero/iam.tf
@@ -5,7 +5,7 @@
  */
 
 resource "azuread_application" "main" {
-  name = "${var.name}-${var.env}-velero"
+  name = "${var.backup_bucket_name}-velero"
 }
 
 resource "azuread_service_principal" "main" {

--- a/modules/azure-velero/input.tf
+++ b/modules/azure-velero/input.tf
@@ -4,14 +4,6 @@
  * license that can be found in the LICENSE file.
  */
 
-variable "name" {
-  type        = string
-  description = "Cluster Name"
-}
-variable "env" {
-  type        = string
-  description = "Environment Name"
-}
 variable "backup_bucket_name" {
   type        = string
   description = "Backup Bucket Name"
@@ -31,6 +23,12 @@ variable "aks_resource_group_name" {
 variable "velero_resource_group_name" {
   type        = string
   description = "Resouce group in which to create velero resources"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Custom tags to apply to resources"
+  default     = {}
 }
 
 data "azurerm_client_config" "main" {}

--- a/modules/azure-velero/output.tf
+++ b/modules/azure-velero/output.tf
@@ -21,6 +21,7 @@ stringData:
     AZURE_RESOURCE_GROUP=${data.azurerm_resource_group.aks.name}
     AZURE_CLOUD_NAME=${var.azure_cloud_name}
 EOF
+
   backup_storage_location  = <<EOF
 ---
 apiVersion: velero.io/v1
@@ -36,6 +37,7 @@ spec:
     resourceGroup: ${data.azurerm_resource_group.velero.name}
     storageAccount: ${azurerm_storage_account.main.name}
 EOF
+
   volume_snapshot_location = <<EOF
 ---
 apiVersion: velero.io/v1

--- a/modules/azure-velero/velero.tf
+++ b/modules/azure-velero/velero.tf
@@ -5,7 +5,7 @@
  */
 
 resource "azurerm_storage_account" "main" {
-  name                     = "${var.name}${var.env}velero"
+  name                     = "${var.backup_bucket_name}velero"
   resource_group_name      = data.azurerm_resource_group.velero.name
   location                 = data.azurerm_resource_group.velero.location
   account_kind             = "BlobStorage"
@@ -17,11 +17,7 @@ resource "azurerm_storage_account" "main" {
   # enable_blob_encryption    = true
   enable_https_traffic_only = true
 
-  tags = {
-    Name        = "${var.name}${var.env}velero"
-    ClusterName = var.name
-    Environment = var.env
-  }
+  tags = var.tags
 }
 
 resource "azurerm_storage_container" "main" {

--- a/modules/eks-velero/README.md
+++ b/modules/eks-velero/README.md
@@ -14,7 +14,7 @@ Kubernetes objects and trigger volume snapshots.
 | -------------------- | -------------------------------------- | ------------- | ------- | :------: |
 | backup\_bucket\_name | Backup Bucket Name                     | `string`      | n/a     |   yes    |
 | oidc\_provider\_url  | EKS OIDC issuer discovery document URL | `string`      | n/a     |   yes    |
-| tags                 | AWS Region where colocate the bucket   | `map(string)` | `{}`    |   no     |
+| tags                 | Custom tags to apply to resources      | `map(string)` | `{}`    |   no     |
 
 ## Outputs
 

--- a/modules/eks-velero/README.md
+++ b/modules/eks-velero/README.md
@@ -10,13 +10,11 @@ Kubernetes objects and trigger volume snapshots.
 
 ## Inputs
 
-| Name                 | Description                            | Type     | Default | Required |
-| -------------------- | -------------------------------------- | -------- | ------- | :------: |
-| backup\_bucket\_name | Backup Bucket Name                     | `string` | n/a     |   yes    |
-| env                  | Environment Name                       | `string` | n/a     |   yes    |
-| name                 | Cluster Name                           | `string` | n/a     |   yes    |
-| oidc\_provider\_url  | EKS OIDC issuer discovery document URL | `string` | n/a     |   yes    |
-| region               | AWS Region where colocate the bucket   | `string` | n/a     |   yes    |
+| Name                 | Description                            | Type          | Default | Required |
+| -------------------- | -------------------------------------- | ------------- | ------- | :------: |
+| backup\_bucket\_name | Backup Bucket Name                     | `string`      | n/a     |   yes    |
+| oidc\_provider\_url  | EKS OIDC issuer discovery document URL | `string`      | n/a     |   yes    |
+| tags                 | AWS Region where colocate the bucket   | `map(string)` | `{}`    |   no     |
 
 ## Outputs
 
@@ -35,11 +33,11 @@ data "aws_eks_cluster" "this" {
 
 module "velero" {
   source             = "../vendor/modules/eks-velero"
-  name               = "my-cluster"
-  env                = "staging"
   backup_bucket_name = "my-cluster-staging-velero"
   oidc_provider_url  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
-  region             = "eu-west-1"
+  tags = {
+    "my-key": "my-value"
+  }
 }
 ```
 

--- a/modules/eks-velero/iam.tf
+++ b/modules/eks-velero/iam.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_iam_policy" "velero_backup" {
-  name = "${var.name}-${var.env}-velero-backup"
+  name = "${var.backup_bucket_name}-velero-policy"
 
   policy = <<EOF
 {
@@ -47,7 +47,7 @@ EOF
 }
 
 resource "aws_iam_role" "velero_backup" {
-  name = "${var.name}-${var.env}-velero-backup"
+  name = "${var.backup_bucket_name}-velero-role"
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/modules/eks-velero/iam.tf
+++ b/modules/eks-velero/iam.tf
@@ -47,7 +47,7 @@ EOF
 }
 
 resource "aws_iam_role" "velero_backup" {
-  name = "${var.backup_bucket_name}-velero-role"
+  name               = "${var.backup_bucket_name}-velero-role"
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -70,6 +70,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "velero_backup" {
-  role = aws_iam_role.velero_backup.name
+  role       = aws_iam_role.velero_backup.name
   policy_arn = aws_iam_policy.velero_backup.arn
 }

--- a/modules/eks-velero/input.tf
+++ b/modules/eks-velero/input.tf
@@ -4,16 +4,6 @@
  * license that can be found in the LICENSE file.
  */
 
-variable "name" {
-  type        = string
-  description = "Cluster Name"
-}
-
-variable "env" {
-  type        = string
-  description = "Environment Name"
-}
-
 variable "oidc_provider_url" {
   type = string
   description = "URL of OIDC issuer discovery document"
@@ -25,9 +15,10 @@ variable "backup_bucket_name" {
   description = "Backup Bucket Name"
 }
 
-variable "region" {
-  type        = string
-  description = "AWS Region where colocate the bucket"
+variable "tags" {
+  type        = map(string)
+  description = "Custom tags to apply to resources"
+  default     = {}
 }
 
 data "aws_caller_identity" "current" {}

--- a/modules/eks-velero/input.tf
+++ b/modules/eks-velero/input.tf
@@ -5,9 +5,9 @@
  */
 
 variable "oidc_provider_url" {
-  type = string
+  type        = string
   description = "URL of OIDC issuer discovery document"
-  default = ""
+  default     = ""
 }
 
 variable "backup_bucket_name" {

--- a/modules/eks-velero/output.tf
+++ b/modules/eks-velero/output.tf
@@ -46,8 +46,9 @@ spec:
   objectStorage:
     bucket: ${aws_s3_bucket.backup_bucket.bucket}
   config:
-    region: ${var.region}
+    region: ${aws_s3_bucket.backup_bucket.region}
 EOF
+
   volume_snapshot_location = <<EOF
 ---
 apiVersion: velero.io/v1
@@ -58,7 +59,7 @@ metadata:
 spec:
   provider: velero.io/aws
   config:
-    region: ${var.region}
+    region: ${aws_s3_bucket.backup_bucket.region}
 EOF
 }
 

--- a/modules/eks-velero/output.tf
+++ b/modules/eks-velero/output.tf
@@ -34,7 +34,7 @@ spec:
         $patch: delete
 EOF
 
-  backup_storage_location  = <<EOF
+  backup_storage_location = <<EOF
 ---
 apiVersion: velero.io/v1
 kind: BackupStorageLocation
@@ -65,7 +65,7 @@ EOF
 
 output "kubernetes_patches" {
   description = "Velero Kubernetes resources patches"
-  value = local.service_account
+  value       = local.service_account
 }
 
 output "backup_storage_location" {

--- a/modules/eks-velero/s3.tf
+++ b/modules/eks-velero/s3.tf
@@ -21,9 +21,5 @@ resource "aws_s3_bucket" "backup_bucket" {
     }
   }
 
-  tags = {
-    Name        = var.backup_bucket_name
-    ClusterName = var.name
-    Environment = var.env
-  }
+  tags = var.tags
 }

--- a/modules/gcp-velero/README.md
+++ b/modules/gcp-velero/README.md
@@ -5,12 +5,11 @@ to backup Kubernetes objects and trigger volume snapshots.
 
 ## Inputs
 
-| Name                 | Description                           | Type     | Default | Required |
-| -------------------- | ------------------------------------- | -------- | ------- | :------: |
-| backup\_bucket\_name | Backup Bucket Name                    | `string` | n/a     |   yes    |
-| env                  | Environment Name                      | `string` | n/a     |   yes    |
-| name                 | Cluster Name                          | `string` | n/a     |   yes    |
-| project              | GCP Project where colocate the bucket | `string` | n/a     |   yes    |
+| Name                 | Description                            | Type          | Default | Required |
+| -------------------- | -------------------------------------- | ------------- | ------- | :------: |
+| backup\_bucket\_name | Backup Bucket Name                     | `string`      | n/a     |   yes    |
+| project              | GCP Project where colocate the bucket  | `string`      | n/a     |   yes    |
+| tags                 | Custom labels to apply to resources    | `map(string)` | `{}`    |   no     |
 
 ## Outputs
 
@@ -25,10 +24,11 @@ to backup Kubernetes objects and trigger volume snapshots.
 ```hcl
 module "velero" {
   source             = "../vendor/modules/gcp-velero"
-  name               = "my-cluster"
-  env                = "staging"
   backup_bucket_name = "my-cluster-staging-velero"
   project            = "sighup-staging"
+  tags               = {
+    "my-key": "my-value"
+  }
 }
 ```
 

--- a/modules/gcp-velero/gcs.tf
+++ b/modules/gcp-velero/gcs.tf
@@ -14,6 +14,8 @@ resource "google_storage_bucket" "main" {
   lifecycle {
     prevent_destroy = false
   }
+
+  labels = var.tags
 }
 
 resource "google_storage_bucket_iam_binding" "velero_bucket_iam" {

--- a/modules/gcp-velero/iam.tf
+++ b/modules/gcp-velero/iam.tf
@@ -6,8 +6,8 @@
 
 resource "google_service_account" "velero" {
   project      = var.project
-  account_id   = "${var.name}-${var.env}-velero"
-  display_name = "Velero account for ${var.name} at ${var.env}"
+  account_id   = "${var.backup_bucket_name}-velero"
+  display_name = "Velero account for ${var.backup_bucket_name}"
 }
 
 resource "google_service_account_key" "velero" {

--- a/modules/gcp-velero/input.tf
+++ b/modules/gcp-velero/input.tf
@@ -9,15 +9,13 @@ variable "project" {
   type        = string
 }
 
-variable "name" {
-  type        = string
-  description = "Cluster Name"
-}
-variable "env" {
-  type        = string
-  description = "Environment Name"
-}
 variable "backup_bucket_name" {
   type        = string
   description = "Backup Bucket Name"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Custom tags to apply to resources"
+  default     = {}
 }

--- a/modules/gcp-velero/output.tf
+++ b/modules/gcp-velero/output.tf
@@ -29,6 +29,7 @@ spec:
     bucket: ${google_storage_bucket.main.name}
     prefix: velero
 EOF
+
   volume_snapshot_location = <<EOF
 ---
 apiVersion: velero.io/v1


### PR DESCRIPTION
Following the same logic of https://github.com/sighupio/fury-kubernetes-furyagent/pull/1 I have simplified the interface of the terraform modules in the following way:

- allowing arbitrary `tags` 
- removing unnecessary inputs `env` and `name` 