### PR TITLE
Fix missing permission and add workload identity in gcp velero

### DIFF
--- a/katalog/velero/velero-gcp/kustomization.yaml
+++ b/katalog/velero/velero-gcp/kustomization.yaml
@@ -14,6 +14,9 @@ images:
   - name: velero/velero-plugin-for-gcp
     newName: registry.sighup.io/fury/velero/velero-plugin-for-gcp
     newTag: v1.1.0
+  - name: velero/velero-plugin-for-csi
+    newName: registry.sighup.io/fury/velero/velero-plugin-for-csi
+    newTag: v0.1.2
 
 patchesStrategicMerge:
   - plugin-patch.yaml

--- a/katalog/velero/velero-gcp/plugin-patch.yaml
+++ b/katalog/velero/velero-gcp/plugin-patch.yaml
@@ -19,7 +19,7 @@ spec:
         volumeMounts:
         - mountPath: /target
           name: plugins
-      - image: velero/velero-plugin-for-csi:v0.1.2
+      - image: velero/velero-plugin-for-csi
         imagePullPolicy: Always
         name: velero-plugin-csi
         securityContext:

--- a/katalog/velero/velero-gcp/plugin-patch.yaml
+++ b/katalog/velero/velero-gcp/plugin-patch.yaml
@@ -19,3 +19,12 @@ spec:
         volumeMounts:
         - mountPath: /target
           name: plugins
+      - image: velero/velero-plugin-for-csi:v0.1.2
+        imagePullPolicy: Always
+        name: velero-plugin-csi
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /target
+          name: plugins
+

--- a/modules/gcp-velero/README.md
+++ b/modules/gcp-velero/README.md
@@ -12,24 +12,21 @@ to backup Kubernetes objects and trigger volume snapshots.
 | gcp_service_account_name                     | Name of the gcp service account to create for velero                          | `string`      | `"velero-sa"`   | yes      |
 | gcp_custom_role_name                         | Name of the gcp custom role to assign to the gcp service account              | `string`      | `"velero_role"` | yes      |
 | workload_identity                            | Flag to specify if velero should use workload identity instead of credentials | `bool`        | `true`          | yes      |
-| workload_identity_kubernetes_service_account | Name of the kubernetes service account that will use the workload identity    | `string`      | `velero-sa`     | yes`*`   |
 | tags                                         | Custom tags to apply to resources                                             | `map(string)` | `{}`            | no       |
-
-`*` if `workload_identity` is enabled (ignored otherwise)
 
 ## Outputs
 
-| Name                         | Description                                                      |
-|------------------------------|------------------------------------------------------------------|
-| backup\_storage\_location    | Velero Cloud BackupStorageLocation CRD                           |
-| cloud\_credentials           | Velero service credentials in case workload identity is not used |
-| volume\_snapshot\_location   | Velero Cloud VolumeSnapshotLocation CRD                          |
-| kubernetes\_service\_account | Kubernetes service account to deploy to use workload identity    |
+| Name                               | Description                                                       |
+|------------------------------------|-------------------------------------------------------------------|
+| backup\_storage\_location          | Velero Cloud BackupStorageLocation CRD                            |
+| cloud\_credentials                 | Velero service credentials in case workload identity is not used  |
+| volume\_snapshot\_location         | Velero Cloud VolumeSnapshotLocation CRD                           |
+| kubernetes\_service\_account_patch | Patch for the Kubernetes service account to use workload identity |
 
 If `workload_identity` is enabled (default behaviour):
 
-- `cloud\_credentials` will not be present in the output
-- use `kubernetes_service_account` to deploy a Kubernetes service account linked to the gcp service account.
+- `cloud_credentials` will not be present in the output
+- `kubernetes_service_account_patch` should be used to patch the Kubernetes service account `velero` to link it to the gcp service account.
 
 To find out more about workload identity go to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identitys).
 

--- a/modules/gcp-velero/README.md
+++ b/modules/gcp-velero/README.md
@@ -5,27 +5,58 @@ to backup Kubernetes objects and trigger volume snapshots.
 
 ## Inputs
 
-| Name                 | Description                            | Type          | Default | Required |
-| -------------------- | -------------------------------------- | ------------- | ------- | :------: |
-| backup\_bucket\_name | Backup Bucket Name                     | `string`      | n/a     |   yes    |
-| project              | GCP Project where colocate the bucket  | `string`      | n/a     |   yes    |
-| tags                 | Custom labels to apply to resources    | `map(string)` | `{}`    |   no     |
+| Name                                         | Description                                                                   | Type          | Default         | Required |
+|----------------------------------------------|-------------------------------------------------------------------------------|---------------|-----------------|--:-:-----|
+| backup\_bucket\_name                         | Backup Bucket Name                                                            | `string`      | `n/a`           | yes      |
+| project                                      | GCP Project where colocate the bucket                                         | `string`      | `n/a`           | yes      |
+| gcp_service_account_name                     | Name of the gcp service account to create for velero                          | `string`      | `"velero-sa"`   | yes      |
+| gcp_custom_role_name                         | Name of the gcp custom role to assign to the gcp service account              | `string`      | `"velero_role"` | yes      |
+| workload_identity                            | Flag to specify if velero should use workload identity instead of credentials | `bool`        | `true`          | yes      |
+| workload_identity_kubernetes_service_account | Name of the kubernetes service account that will use the workload identity    | `string`      | `velero-sa`     | yes`*`   |
+| tags                                         | Custom tags to apply to resources                                             | `map(string)` | `{}`            | no       |
+
+`*` if `workload_identity` is enabled (ignored otherwise)
 
 ## Outputs
 
-| Name                       | Description                             |
-| -------------------------- | --------------------------------------- |
-| backup\_storage\_location  | Velero Cloud BackupStorageLocation CRD  |
-| cloud\_credentials         | Velero required file with credentials   |
-| volume\_snapshot\_location | Velero Cloud VolumeSnapshotLocation CRD |
+| Name                         | Description                                                      |
+|------------------------------|------------------------------------------------------------------|
+| backup\_storage\_location    | Velero Cloud BackupStorageLocation CRD                           |
+| cloud\_credentials           | Velero service credentials in case workload identity is not used |
+| volume\_snapshot\_location   | Velero Cloud VolumeSnapshotLocation CRD                          |
+| kubernetes\_service\_account | Kubernetes service account to deploy to use workload identity    |
+
+If `workload_identity` is enabled (default behaviour):
+
+- `cloud\_credentials` will not be present in the output
+- use `kubernetes_service_account` to deploy a Kubernetes service account linked to the gcp service account.
+
+To find out more about workload identity go to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identitys).
 
 ## Usage
+
+With workload identity:
 
 ```hcl
 module "velero" {
   source             = "../vendor/modules/gcp-velero"
   backup_bucket_name = "my-cluster-staging-velero"
   project            = "sighup-staging"
+  tags               = {
+    "my-key": "my-value"
+  }
+}
+```
+
+To disable workload identity:
+
+```hcl
+module "velero" {
+  source             = "../vendor/modules/gcp-velero"
+  backup_bucket_name = "my-cluster-staging-velero"
+  project            = "sighup-staging"
+  workload_identity  = false
+
   tags               = {
     "my-key": "my-value"
   }

--- a/modules/gcp-velero/README.md
+++ b/modules/gcp-velero/README.md
@@ -5,34 +5,43 @@ to backup Kubernetes objects and trigger volume snapshots.
 
 ## Inputs
 
-| Name                                         | Description                                                                   | Type          | Default         | Required |
-|----------------------------------------------|-------------------------------------------------------------------------------|---------------|-----------------|--:-:-----|
-| backup\_bucket\_name                         | Backup Bucket Name                                                            | `string`      | `n/a`           | yes      |
-| project                                      | GCP Project where colocate the bucket                                         | `string`      | `n/a`           | yes      |
-| gcp_service_account_name                     | Name of the gcp service account to create for velero                          | `string`      | `"velero-sa"`   | yes      |
-| gcp_custom_role_name                         | Name of the gcp custom role to assign to the gcp service account              | `string`      | `"velero_role"` | yes      |
-| workload_identity                            | Flag to specify if velero should use workload identity instead of credentials | `bool`        | `true`          | yes      |
-| tags                                         | Custom tags to apply to resources                                             | `map(string)` | `{}`            | no       |
+| Name                     | Description                                                                   | Type          | Default         | Required |
+|--------------------------|-------------------------------------------------------------------------------|---------------|-----------------|--:-:-----|
+| backup\_bucket\_name     | Backup Bucket Name                                                            | `string`      | `n/a`           | yes      |
+| project                  | GCP Project where colocate the bucket                                         | `string`      | `n/a`           | yes      |
+| gcp_service_account_name | Name of the gcp service account to create for velero                          | `string`      | `"velero-sa"`   | yes      |
+| gcp_custom_role_name     | Name of the gcp custom role to assign to the gcp service account              | `string`      | `"velero_role"` | yes      |
+| workload_identity        | Flag to specify if velero should use workload identity instead of credentials | `bool`        | `false`         | yes      |
+| tags                     | Custom tags to apply to resources                                             | `map(string)` | `{}`            | no       |
+
 
 ## Outputs
 
 | Name                               | Description                                                       |
 |------------------------------------|-------------------------------------------------------------------|
-| backup\_storage\_location          | Velero Cloud BackupStorageLocation CRD                            |
-| cloud\_credentials                 | Velero service credentials in case workload identity is not used  |
-| volume\_snapshot\_location         | Velero Cloud VolumeSnapshotLocation CRD                           |
-| kubernetes\_service\_account_patch | Patch for the Kubernetes service account to use workload identity |
+| `backup_storage_location`          | Velero Cloud BackupStorageLocation CRD                            |
+| `cloud_credentials`                | Velero service credentials in case workload identity is not used  |
+| `volume_snapshot_location`         | Velero Cloud VolumeSnapshotLocation CRD                           |
+| `kubernetes_service_account_patch` | Patch for the Kubernetes service account to use workload identity |
+| `remove_velero_credentials_patch`  | Patch to remove service account credentials in velero             |
+| `remove_restic_credentials_patch`  | Patch to remove service account credentials in velero restic      |
 
-If `workload_identity` is enabled (default behaviour):
+The presence of some outputs is conditional to the presence of `workload_identity`:
 
-- `cloud_credentials` will not be present in the output
-- `kubernetes_service_account_patch` should be used to patch the Kubernetes service account `velero` to link it to the gcp service account.
+| Name                               | Default            | Workload Identity  |
+|------------------------------------|--------------------|--------------------|
+| `backup_storage_location`          | :white_check_mark: | :white_check_mark: |
+| `cloud_credentials`                | :white_check_mark: | :x:                |
+| `volume_snapshot_location`         | :white_check_mark: | :white_check_mark: |
+| `kubernetes_service_account_patch` | :x:                | :white_check_mark: |
+| `remove_velero_credentials_patch`  | :x:                | :white_check_mark: |
+| `remove_restic_credentials_patch`  | :x:                | :white_check_mark: |
 
 To find out more about workload identity go to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identitys).
 
 ## Usage
 
-With workload identity:
+Without workload identity:
 
 ```hcl
 module "velero" {
@@ -45,15 +54,14 @@ module "velero" {
 }
 ```
 
-To disable workload identity:
+To enable workload identity:
 
 ```hcl
 module "velero" {
   source             = "../vendor/modules/gcp-velero"
   backup_bucket_name = "my-cluster-staging-velero"
   project            = "sighup-staging"
-  workload_identity  = false
-
+  workload_identity  = true
   tags               = {
     "my-key": "my-value"
   }

--- a/modules/gcp-velero/gcs.tf
+++ b/modules/gcp-velero/gcs.tf
@@ -5,7 +5,7 @@
  */
 
 # Create a unique GCS bucket per cluster
-resource "google_storage_bucket" "main" {
+resource "google_storage_bucket" "velero" {
   name                        = var.backup_bucket_name
   uniform_bucket_level_access = true
   project                     = var.project
@@ -19,7 +19,7 @@ resource "google_storage_bucket" "main" {
 }
 
 resource "google_storage_bucket_iam_binding" "velero_bucket_iam" {
-  bucket = google_storage_bucket.main.name
+  bucket = google_storage_bucket.velero.name
   role   = "roles/storage.objectAdmin"
 
   members = [

--- a/modules/gcp-velero/gcs.tf
+++ b/modules/gcp-velero/gcs.tf
@@ -5,7 +5,7 @@
  */
 
 # Create a unique GCS bucket per cluster
-resource "google_storage_bucket" "velero" {
+resource "google_storage_bucket" "main" {
   name                        = var.backup_bucket_name
   uniform_bucket_level_access = true
   project                     = var.project
@@ -19,7 +19,7 @@ resource "google_storage_bucket" "velero" {
 }
 
 resource "google_storage_bucket_iam_binding" "velero_bucket_iam" {
-  bucket = google_storage_bucket.velero.name
+  bucket = google_storage_bucket.main.name
   role   = "roles/storage.objectAdmin"
 
   members = [

--- a/modules/gcp-velero/iam.tf
+++ b/modules/gcp-velero/iam.tf
@@ -4,12 +4,42 @@
  * license that can be found in the LICENSE file.
  */
 
+resource "random_id" "velero" {
+  byte_length = 2
+}
+
 resource "google_service_account" "velero" {
   project      = var.project
-  account_id   = "${var.backup_bucket_name}-velero"
+  account_id   = "velero-sa-${random_id.velero.hex}"
   display_name = "Velero account for ${var.backup_bucket_name}"
 }
 
 resource "google_service_account_key" "velero" {
   service_account_id = google_service_account.velero.name
 }
+
+# Custom role 
+resource "google_project_iam_custom_role" "velero-role" {
+  role_id     = "velero_role_${random_id.velero.hex}"
+  title       = "Velero Role"
+  description = "Custom role to assign to velero sa to allow it to create snapshots"
+  permissions = [
+    "compute.disks.get",
+    "compute.disks.list",
+    "compute.disks.create",
+    "compute.disks.createSnapshot",
+    "compute.snapshots.get",
+    "compute.snapshots.list",
+    "compute.snapshots.create",
+    "compute.snapshots.useReadOnly",
+    "compute.snapshots.delete",
+    "compute.zones.get"
+  ]
+}
+
+resource "google_project_iam_member" "project" {
+  project = var.project
+  role    = google_project_iam_custom_role.velero-role.id
+  member  = "serviceAccount:${google_service_account.velero.email}"
+}
+

--- a/modules/gcp-velero/iam.tf
+++ b/modules/gcp-velero/iam.tf
@@ -4,26 +4,8 @@
  * license that can be found in the LICENSE file.
  */
 
-resource "random_id" "velero" {
-  byte_length = 2
-}
-
-resource "google_service_account" "velero" {
-  project      = var.project
-  account_id   = "velero-sa-${random_id.velero.hex}"
-  display_name = "Velero account for ${var.backup_bucket_name}"
-}
-
-resource "google_service_account_key" "velero" {
-  service_account_id = google_service_account.velero.name
-}
-
-# Custom role 
-resource "google_project_iam_custom_role" "velero-role" {
-  role_id     = "velero_role_${random_id.velero.hex}"
-  title       = "Velero Role"
-  description = "Custom role to assign to velero sa to allow it to create snapshots"
-  permissions = [
+locals {
+  velero_role_permissions = [
     "compute.disks.get",
     "compute.disks.list",
     "compute.disks.create",
@@ -37,9 +19,35 @@ resource "google_project_iam_custom_role" "velero-role" {
   ]
 }
 
+resource "google_service_account" "velero" {
+  project      = var.project
+  account_id   = var.google_service_account_name
+  display_name = "Service account for Velero"
+}
+
+resource "google_service_account_key" "velero" {
+  service_account_id = google_service_account.velero.name
+}
+
+resource "google_project_iam_custom_role" "velero-role" {
+  role_id     = "${replace(var.google_service_account_name, "-", "_")}_role"
+  title       = "Velero Role"
+  description = "Custom role to assign to velero sa to allow it to create snapshots"
+  permissions = var.workload_identity ? concat(local.velero_role_permissions, ["iam.serviceAccounts.signBlob"]) : local.velero_role_permissions
+}
+
 resource "google_project_iam_member" "project" {
   project = var.project
   role    = google_project_iam_custom_role.velero-role.id
   member  = "serviceAccount:${google_service_account.velero.email}"
 }
 
+# Workload identity
+resource "google_service_account_iam_binding" "roles" {
+  count = var.workload_identity ? 1 : 0
+  members = [
+    "serviceAccount:niccolo-raspa-test-project.svc.id.goog[kube-system/${var.workload_identity_kubernetes_service_account}]",
+  ]
+  role               = "roles/iam.workloadIdentityUser"
+  service_account_id = google_service_account.velero.id
+}

--- a/modules/gcp-velero/iam.tf
+++ b/modules/gcp-velero/iam.tf
@@ -29,7 +29,7 @@ resource "google_service_account_key" "velero" {
   service_account_id = google_service_account.velero.name
 }
 
-resource "google_project_iam_custom_role" "velero-role" {
+resource "google_project_iam_custom_role" "velero_role" {
   role_id     = var.gcp_custom_role_name
   title       = "Velero Role"
   description = "Custom role to assign to velero sa to allow it to create snapshots"
@@ -38,7 +38,7 @@ resource "google_project_iam_custom_role" "velero-role" {
 
 resource "google_project_iam_member" "project" {
   project = var.project
-  role    = google_project_iam_custom_role.velero-role.id
+  role    = google_project_iam_custom_role.velero_role.id
   member  = "serviceAccount:${google_service_account.velero.email}"
 }
 

--- a/modules/gcp-velero/iam.tf
+++ b/modules/gcp-velero/iam.tf
@@ -46,7 +46,7 @@ resource "google_project_iam_member" "project" {
 resource "google_service_account_iam_binding" "roles" {
   count = var.workload_identity ? 1 : 0
   members = [
-    "serviceAccount:niccolo-raspa-test-project.svc.id.goog[kube-system/${var.workload_identity_kubernetes_service_account}]",
+    "serviceAccount:${var.project}.svc.id.goog[kube-system/velero]",
   ]
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.velero.id

--- a/modules/gcp-velero/iam.tf
+++ b/modules/gcp-velero/iam.tf
@@ -21,7 +21,7 @@ locals {
 
 resource "google_service_account" "velero" {
   project      = var.project
-  account_id   = var.google_service_account_name
+  account_id   = var.gcp_service_account_name
   display_name = "Service account for Velero"
 }
 
@@ -30,7 +30,7 @@ resource "google_service_account_key" "velero" {
 }
 
 resource "google_project_iam_custom_role" "velero-role" {
-  role_id     = "${replace(var.google_service_account_name, "-", "_")}_role"
+  role_id     = var.gcp_custom_role_name
   title       = "Velero Role"
   description = "Custom role to assign to velero sa to allow it to create snapshots"
   permissions = var.workload_identity ? concat(local.velero_role_permissions, ["iam.serviceAccounts.signBlob"]) : local.velero_role_permissions

--- a/modules/gcp-velero/input.tf
+++ b/modules/gcp-velero/input.tf
@@ -29,7 +29,7 @@ variable "gcp_custom_role_name" {
 variable "workload_identity" {
   type        = bool
   description = "Flag to specify if velero should use workload identity instead of credentials"
-  default     = true
+  default     = false
 }
 
 variable "tags" {

--- a/modules/gcp-velero/input.tf
+++ b/modules/gcp-velero/input.tf
@@ -14,16 +14,16 @@ variable "backup_bucket_name" {
   description = "Backup Bucket Name"
 }
 
-variable "tags" {
-  type        = map(string)
-  description = "Custom tags to apply to resources"
-  default     = {}
-}
-
-variable "google_service_account_name" {
+variable "gcp_service_account_name" {
   type        = string
   description = "Name of the gcp service account to create for velero"
   default     = "velero-sa"
+}
+
+variable "gcp_custom_role_name" {
+  type        = string
+  description = "Name of the gcp custom role to assign to the gcp service account"
+  default     = "velero_role" 
 }
 
 variable "workload_identity" {
@@ -34,6 +34,12 @@ variable "workload_identity" {
 
 variable "workload_identity_kubernetes_service_account" {
   type        = string
-  description = "Name of the service account in kubernetes that will use the workload identity"
+  description = "Name of the kubernetes service account that will use the workload identity"
   default     = "velero-sa"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Custom tags to apply to resources"
+  default     = {}
 }

--- a/modules/gcp-velero/input.tf
+++ b/modules/gcp-velero/input.tf
@@ -32,12 +32,6 @@ variable "workload_identity" {
   default     = true
 }
 
-variable "workload_identity_kubernetes_service_account" {
-  type        = string
-  description = "Name of the kubernetes service account that will use the workload identity"
-  default     = "velero-sa"
-}
-
 variable "tags" {
   type        = map(string)
   description = "Custom tags to apply to resources"

--- a/modules/gcp-velero/input.tf
+++ b/modules/gcp-velero/input.tf
@@ -19,3 +19,21 @@ variable "tags" {
   description = "Custom tags to apply to resources"
   default     = {}
 }
+
+variable "google_service_account_name" {
+  type        = string
+  description = "Name of the gcp service account to create for velero"
+  default     = "velero-sa"
+}
+
+variable "workload_identity" {
+  type        = bool
+  description = "Flag to specify if velero should use workload identity instead of credentials"
+  default     = true
+}
+
+variable "workload_identity_kubernetes_service_account" {
+  type        = string
+  description = "Name of the service account in kubernetes that will use the workload identity"
+  default     = "velero-sa"
+}

--- a/modules/gcp-velero/output.tf
+++ b/modules/gcp-velero/output.tf
@@ -26,7 +26,7 @@ metadata:
 spec:
   provider: velero.io/gcp
   objectStorage:
-    bucket: ${google_storage_bucket.velero.name}
+    bucket: ${google_storage_bucket.main.name}
     prefix: velero
   config:
     serviceAccount: ${google_service_account.velero.email}
@@ -128,13 +128,13 @@ output "kubernetes_service_account_patch" {
 }
 
 output "remove_velero_credentials_patch" {
-  description = "Patch to remove credentials in velero deployment"
+  description = "Patch to remove service account credentials in velero"
   value       = var.workload_identity ? local.remove_velero_credentials_patch : null
   sensitive   = true
 }
 
 output "remove_restic_credentials_patch" {
-  description = "Patch to remove credentials in restic deployment"
+  description = "Patch to remove service account credentials in velero restic"
   value       = var.workload_identity ? local.remove_restic_credentials_patch : null
   sensitive   = true
 }

--- a/modules/gcp-velero/output.tf
+++ b/modules/gcp-velero/output.tf
@@ -26,8 +26,10 @@ metadata:
 spec:
   provider: velero.io/gcp
   objectStorage:
-    bucket: ${google_storage_bucket.main.name}
+    bucket: ${google_storage_bucket.velero.name}
     prefix: velero
+  config:
+    serviceAccount: ${google_service_account.velero.email}
 EOF
 
   volume_snapshot_location = <<EOF

--- a/modules/gcp-velero/output.tf
+++ b/modules/gcp-velero/output.tf
@@ -43,34 +43,37 @@ spec:
   provider: velero.io/gcp
 EOF
 
-  kubernetes_service_account = <<EOF
+  kubernetes_service_account_patch = <<EOF
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annottions:
+  name: velero
+  annotations:
     iam.gke.io/gcp-service-account: ${google_service_account.velero.email}
-  namespace: kube-system
-  name: ${var.workload_identity_kubernetes_service_account}
 EOF
 }
 
 output "cloud_credentials" {
   description = "Velero required file with credentials in case no workload identity is used"
   value       = var.workload_identity ? null : local.cloud_credentials
+  sensitive   = true
 }
 
 output "backup_storage_location" {
   description = "Velero Cloud BackupStorageLocation CRD"
   value       = local.backup_storage_location
+  sensitive   = true
 }
 
 output "volume_snapshot_location" {
   description = "Velero Cloud VolumeSnapshotLocation CRD"
   value       = local.volume_snapshot_location
+  sensitive   = true
 }
 
-output "kubernetes_service_account" {
-  description = "Kubernetes service account to deploy to use workload identity"
-  value       = var.workload_identity ? local.velero_kubernetes_service_account : null
-
+output "kubernetes_service_account_patch" {
+  description = "Patch for the Kubernetes service account to use workload identity"
+  value       = var.workload_identity ? local.kubernetes_service_account_patch : null
+  sensitive   = true
 }

--- a/modules/gcp-velero/output.tf
+++ b/modules/gcp-velero/output.tf
@@ -43,7 +43,7 @@ spec:
   provider: velero.io/gcp
 EOF
 
-  velero_kubernetes_service_account = <<EOF
+  kubernetes_service_account = <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -70,7 +70,7 @@ output "volume_snapshot_location" {
 }
 
 output "kubernetes_service_account" {
-  description = "Service account to create in the GKE cluster to use workload identity"
+  description = "Kubernetes service account to deploy to use workload identity"
   value       = var.workload_identity ? local.velero_kubernetes_service_account : null
 
 }


### PR DESCRIPTION
As pointed out in https://github.com/sighupio/fury-kubernetes-dr/issues/30 the current implementation is lacking the necessary permission to perform snapshots of the volumes.

This PR addresses the aforemention issue by creating a custom role for velero with the necessary permissions:

```hcl
  velero_role_permissions = [
    "compute.disks.get",
    "compute.disks.list",
    "compute.disks.create",
    "compute.disks.createSnapshot",
    "compute.snapshots.get",
    "compute.snapshots.list",
    "compute.snapshots.create",
    "compute.snapshots.useReadOnly",
    "compute.snapshots.delete",
    "compute.zones.get"
  ]
```

Check `iam.tf` for more details.

Moreover, this PR introduces the possibility to use **workload-identity** (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) instead of the hardcoded credentials to impersonate the GCP service account.

The workload identity is not enabled by default for backward compatibility but can be enabled by setting the newly defined variable `workload_identity` to `true`.

Example:

```hcl
module "velero" {
  source             = "/path/to/fury-kubernetes-dr/modules/gcp-velero/"
  backup_bucket_name = "my-bucket"
  project            = "my-project"
  workload_identity  = true 
}
```