### PR TITLE
Re-introduce IAM Roles for ServiceAccount support to aws-velero

### DIFF
--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -57,7 +57,7 @@ module "velero" {
 }
 ```
 
-To use IAM Roles support for Service Account:
+To use IAM Roles for Service Accounts (IRSA):
 
 ```hcl
 data "aws_eks_cluster" "this" {
@@ -74,4 +74,4 @@ module "velero" {
 }
 ```
 
-For more information about IAM Roles for ServiceAccount to inject AWS credentials inside Velero's pods, click [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+For more information about IAM Roles for Service Accounts to inject AWS credentials inside Velero's pods, click [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -1,21 +1,48 @@
 # AWS Velero
 
-This terraform module provides an easy way to generate Velero required cloud resources (S3 and IAM) to backup
-Kubernetes objects and trigger volume snapshots.
+This terraform module provides an easy way to generate Velero required cloud resources (S3 and IAM) to backup Kubernetes objects and trigger volume snapshots.
+
+## Requirements
+
+|   Name    | Version  |
+| --------- | -------- |
+| terraform | `0.15.4` |
+| aws       | `3.37.0` |
+
+## Providers
+
+| Name | Version  |
+| ---- | -------- |
+| aws  | `3.37.0` |
+
+## Resources
+
+|                                                                          Name                                                                          |    Type     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| [aws_iam_access_key.velero_backup](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/resources/iam_access_key)                         | resource    |
+| [aws_iam_policy.velero_backup](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/resources/iam_policy)                                 | resource    |
+| [aws_iam_policy_attachment.velero_backup](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/resources/iam_policy_attachment)           | resource    |
+| [aws_iam_role.velero_backup](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/resources/iam_role)                                     | resource    |
+| [aws_iam_role_policy_attachment.velero_backup](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/resources/iam_role_policy_attachment) | resource    |
+| [aws_iam_user.velero_backup_user](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/resources/iam_user)                                | resource    |
+| [aws_s3_bucket.backup_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/resources/s3_bucket)                                   | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/data-sources/caller_identity)                          | data source |
 
 ## Inputs
 
-| Name                 | Description                            | Type          | Default | Required |
-| -------------------- | -------------------------------------- | ------------- | ------- | :------: |
-| backup\_bucket\_name | Backup Bucket Name                     | `string`      | n/a     |   yes    |
-| tags                 | Custom tags to apply to resources      | `map(string)` | `{}`    |   no     |
+|         Name         |              Description              |     Type      | Default | Required |
+| -------------------- | ------------------------------------- | ------------- | ------- | :------: |
+| backup\_bucket\_name | Backup Bucket Name                    | `string`      | n/a     |   yes    |
+| oidc\_provider\_url  | URL of OIDC issuer discovery document | `string`      | `""`    |    no    |
+| tags                 | Custom tags to apply to resources     | `map(string)` | `{}`    |    no    |
 
 ## Outputs
 
-| Name                       | Description                             |
+|            Name            |               Description               |
 | -------------------------- | --------------------------------------- |
 | backup\_storage\_location  | Velero Cloud BackupStorageLocation CRD  |
 | cloud\_credentials         | Velero required file with credentials   |
+| service\_account           | Velero ServiceAccount                   |
 | volume\_snapshot\_location | Velero Cloud VolumeSnapshotLocation CRD |
 
 ## Usage
@@ -30,8 +57,21 @@ module "velero" {
 }
 ```
 
-## Links
+To use IAM Roles support for Service Account:
 
-- [https://github.com/vmware-tanzu/velero-plugin-for-aws/tree/v1.3.0#setup](https://github.com/vmware-tanzu/velero-plugin-for-aws/tree/v1.3.0#setup)
-- [https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.3.0/backupstoragelocation.md](https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.3.0/backupstoragelocation.md)
-- [https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.3.0/volumesnapshotlocation.md](https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.3.0/volumesnapshotlocation.md)
+```hcl
+data "aws_eks_cluster" "this" {
+  name = "my-cluster-staging"
+}
+
+module "velero" {
+  source             = "../vendor/modules/aws-velero"
+  backup_bucket_name = "my-cluster-staging-velero"
+  oidc_provider_url  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
+  tags               = {
+    "my-key": "my-value"
+  }
+}
+```
+
+For more information about IAM Roles for ServiceAccount to inject AWS credentials inside Velero's pods click [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -74,4 +74,4 @@ module "velero" {
 }
 ```
 
-For more information about IAM Roles for ServiceAccount to inject AWS credentials inside Velero's pods click [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+For more information about IAM Roles for ServiceAccount to inject AWS credentials inside Velero's pods, click [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

--- a/modules/aws-velero/iam.tf
+++ b/modules/aws-velero/iam.tf
@@ -5,19 +5,22 @@
  */
 
 resource "aws_iam_user" "velero_backup_user" {
+  count = length(var.oidc_provider_url) != 0 ? 0 : 1
   name = "${var.backup_bucket_name}-velero-backup"
   path = "/"
   tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "velero_backup" {
+  count = length(var.oidc_provider_url) != 0 ? 0 : 1
   name       = "${var.backup_bucket_name}-velero-backup"
-  users      = [aws_iam_user.velero_backup_user.name]
+  users      = [aws_iam_user.velero_backup_user.0.name]
   policy_arn = aws_iam_policy.velero_backup.arn
 }
 
 resource "aws_iam_access_key" "velero_backup" {
-  user = aws_iam_user.velero_backup_user.name
+  count = length(var.oidc_provider_url) != 0 ? 0 : 1
+  user = aws_iam_user.velero_backup_user.0.name
 }
 
 resource "aws_iam_policy" "velero_backup" {
@@ -60,4 +63,34 @@ resource "aws_iam_policy" "velero_backup" {
      ]
 }
 EOF
+}
+
+resource "aws_iam_role" "velero_backup" {
+  count = length(var.oidc_provider_url) != 0 ? 1 : 0
+  name = "${var.name}-${var.env}-velero-backup"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${var.oidc_provider_url}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "${var.oidc_provider_url}:sub": "system:serviceaccount:kube-system:velero"
+                }
+            }
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "velero_backup" {
+  count = length(var.oidc_provider_url) != 0 ? 1 : 0
+  role = aws_iam_role.velero_backup.0.name
+  policy_arn = aws_iam_policy.velero_backup.arn
 }

--- a/modules/aws-velero/input.tf
+++ b/modules/aws-velero/input.tf
@@ -15,4 +15,10 @@ variable "tags" {
   default     = {}
 }
 
+variable "oidc_provider_url" {
+  type = string
+  description = "URL of OIDC issuer discovery document"
+  default = ""
+}
+
 data "aws_caller_identity" "current" {}

--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -19,6 +19,17 @@ stringData:
     aws_secret_access_key=${aws_iam_access_key.velero_backup.secret}
 EOF
 
+    service_account = <<EOF
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: ${element(coalescelist(aws_iam_role.velero_backup.*.arn, [""]), 0)}
+  name: velero
+  namespace: kube-system
+EOF
+
   backup_storage_location = <<EOF
 ---
 apiVersion: velero.io/v1
@@ -61,4 +72,9 @@ output "backup_storage_location" {
 output "volume_snapshot_location" {
   description = "Velero Cloud VolumeSnapshotLocation CRD"
   value       = local.volume_snapshot_location
+}
+
+output "service_account" {
+  description = "Velero ServiceAccount"
+  value = local.service_account
 }


### PR DESCRIPTION
Re-adding the changes of @lnovara PR: https://github.com/sighupio/fury-kubernetes-dr/pull/19/ to extend `Velero on AWS` with the possibility to specify IAM Roles for ServiceAccount.

This functionality is currently being offered by [eks-velero](https://github.com/sighupio/fury-kubernetes-dr/tree/master/modules/eks-velero).  eks-velero will be deprecated and then removed in future module releases.

References:
- https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html