### PR TITLE
Fix broken aws-velero Terraform module

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -43,6 +43,8 @@ steps:
       VALIDATE_JSCPD: "false"
       VALIDATE_TERRAFORM_TFLINT: "false"
       VALIDATE_DOCKERFILE: "false"
+      # Disable natural language checks
+      VALIDATE_NATURAL_LANGUAGE: "false"
     depends_on:
       - clone
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     Kubernetes Fury DR
 </h1>
 
-![Release](https://img.shields.io/github/v/release/sighupio/fury-kubernetes-dr?label=Latest%20Release)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.9.3-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-dr?label=License)
 [![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)](https://kubernetes.slack.com/archives/C0154HYTAQH)
 

--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ To deploy Velero on AWS:
 ```yaml
 bases:
   - name: dr/velero/velero-aws
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: dr/velero/velero-restic
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: dr/velero/velero-schedules
-    version: "v1.9.2"
+    version: "v1.9.3"
 
 modules:
   - name: dr/aws-velero
-    version: "v1.9.2"
+    version: "v1.9.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -171,15 +171,15 @@ To deploy Velero on GCP:
 ```yaml
 bases:
   - name: dr/velero/velero-gcp
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: dr/velero/velero-restic
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: dr/velero/velero-schedules
-    version: "v1.9.2"
+    version: "v1.9.3"
 
 modules:
   - name: dr/gcp-velero
-    version: "v1.9.2"
+    version: "v1.9.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -230,15 +230,15 @@ To deploy Velero on Azure:
 ```yaml
 bases:
   - name: dr/velero/velero-azure
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: dr/velero/velero-restic
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: dr/velero/velero-schedules
-    version: "v1.9.2"
+    version: "v1.9.3"
 
 modules:
   - name: dr/azure-velero
-    version: "v1.9.2"
+    version: "v1.9.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -289,11 +289,11 @@ To deploy `velero on-prem`:
 ```yaml
 bases:
   - name: velero/velero-on-prem
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: velero/velero-restic
-    version: "v1.9.2"
+    version: "v1.9.3"
   - name: velero/velero-schedules
-    version: "v1.9.2"
+    version: "v1.9.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -43,8 +43,8 @@ WORKDIR /app
 
 COPY . .
 
-RUN conftest pull https://raw.githubusercontent.com/sighupio/ci-commons/main/conftest/kustomization/kfd-labels.rego
-RUN conftest test katalog/velero/velero-base/kustomization.yaml
+RUN conftest pull https://raw.githubusercontent.com/sighupio/ci-commons/main/conftest/kustomization/kfd-labels.rego && \
+  conftest test katalog/velero/velero-base/kustomization.yaml
 
 FROM python:3.9-alpine as bumpversion-requirement
 

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -14,6 +14,7 @@
 | v1.9.0                              |                    |                    |                    |                    |                    |                    | :x:                | :x:                | :x:                | :x:       |
 | v1.9.1                              |                    |                    |                    |                    |                    |                    | :x:                | :x:                | :x:                | :x:       |
 | v1.9.2                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
+| v1.9.3                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 
 :white_check_mark: Compatible
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,8 +65,8 @@ quite difficult to interpret which is the target version for which a `rc` is
 being created. So the example usage is:
 
 ```bash
-$ TAG=v1.9.2-rc1 make bump-rc
-# This essentially creates a tag `v1.9.2-rc1` which we can  push to github to create a pre-release
+$ TAG=v1.9.3-rc1 make bump-rc
+# This essentially creates a tag `v1.9.3-rc1` which we can  push to github to create a pre-release
 ```
 
 Then, in order to release it(assuming from version `1.8.0` to `1.8.1` - so a

--- a/docs/releases/v1.9.3.md
+++ b/docs/releases/v1.9.3.md
@@ -1,0 +1,26 @@
+# Disaster recovery Core Module Release 1.9.3
+
+Welcome to the latest release of `dr` module of [`Kubernetes Fury
+Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
+SIGHUP.
+
+This is a patch release that fixes an issue on the [`aws-velero`](../../modules/aws-velero) Terraform module.
+
+## Component Images 🚢
+
+| Component                           | Supported Version                                                                                 | Previous Version |
+|-------------------------------------|---------------------------------------------------------------------------------------------------|------------------|
+| `velero`                            | [`v1.7.1`](https://github.com/vmware-tanzu/velero/releases/tag/v1.7.1)                            | `No update`      |
+| `velero-plugin-for-aws`             | [`v1.3.0`](https://github.com/vmware-tanzu/velero-plugin-for-aws/releases/tag/v1.3.0)             | `No update`      |
+| `velero-plugin-for-microsoft-azure` | [`v1.3.1`](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/releases/tag/v1.3.1) | `No update`      |
+| `velero-plugin-for-gcp`             | [`v1.3.0`](https://github.com/vmware-tanzu/velero-plugin-for-gcp/releases/tag/v1.3.0)             | `No update`      |
+| `velero-plugin-for-csi`             | [`v0.2.0`](https://github.com/vmware-tanzu/velero-plugin-for-csi/releases/tag/v0.2.0)             | `No update`      |
+
+> Please refer the individual release notes to get a detailed info on the
+> releases.
+
+### Bug Fixes
+
+- [#48](https://github.com/sighupio/fury-kubernetes-dr/pull/48) Fix an issue
+  with [`aws-velero`](../../modules/aws-velero) Terraform module and reintroduce
+  Kustomize patches for Velero Deployment resource as Terraform output.

--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -30,6 +30,27 @@ metadata:
   namespace: kube-system
 EOF
 
+  deployment = <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: velero
+        volumeMounts:
+        - name: cloud-credentials
+          mountPath: /credentials
+          $patch: delete
+      volumes:
+      - name: cloud-credentials
+        $patch: delete
+EOF
+
   backup_storage_location = <<EOF
 ---
 apiVersion: velero.io/v1
@@ -62,6 +83,11 @@ EOF
 output "cloud_credentials" {
   description = "Velero required file with credentials"
   value       = local.cloud_credentials
+}
+
+output "deployment" {
+  description = "Velero Deployment Kustomize patch"
+  value = local.deployment
 }
 
 output "backup_storage_location" {

--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -15,8 +15,8 @@ type: Opaque
 stringData:
   cloud: |-
     [default]
-    aws_access_key_id=${aws_iam_access_key.velero_backup.0.id}
-    aws_secret_access_key=${aws_iam_access_key.velero_backup.0.secret}
+    aws_access_key_id=${element(coalescelist(aws_iam_access_key.velero_backup.*.id, [""]), 0)}
+    aws_secret_access_key=${element(coalescelist(aws_iam_access_key.velero_backup.*.secret, [""]), 0)}
 EOF
 
     service_account = <<EOF

--- a/modules/aws-velero/output.tf
+++ b/modules/aws-velero/output.tf
@@ -81,7 +81,7 @@ EOF
 }
 
 output "cloud_credentials" {
-  description = "Velero required file with credentials"
+  description = "Velero AWS credentials"
   value       = local.cloud_credentials
 }
 
@@ -101,6 +101,6 @@ output "volume_snapshot_location" {
 }
 
 output "service_account" {
-  description = "Velero ServiceAccount"
+  description = "Velero ServiceAccount Kustomize patch"
   value = local.service_account
 }


### PR DESCRIPTION
Trying to use the `aws-module` currently yields the following error:

```
│ Error: Invalid index
│
│   on ../vendor/modules/dr/aws-velero/output.tf line 18, in locals:
│   18:     aws_access_key_id=${aws_iam_access_key.velero_backup.0.id}
│     ├────────────────
│     │ aws_iam_access_key.velero_backup is empty tuple
│
│ The given key does not identify an element in this collection value.
╵
╷
│ Error: Invalid index
│
│   on ../vendor/modules/dr/aws-velero/output.tf line 19, in locals:
│   19:     aws_secret_access_key=${aws_iam_access_key.velero_backup.0.secret}
│     ├────────────────
│     │ aws_iam_access_key.velero_backup is empty tuple
│
│ The given key does not identify an element in this collection value.
```

The aim of this PR is to fix this error and bring a couple of additional improvements, namely:
  - adding back the Kustomize patch for the Deployment resource
  - slightly improving the description of some outputs