### PR TITLE
feat: put dashboards in "Disaster Recovery" grafana folder

### DIFF
--- a/katalog/velero/velero-base/dashboards/kustomization.yaml
+++ b/katalog/velero/velero-base/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: kube-system
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Disaster Recovery"
   disableNameSuffixHash: true
 
 configMapGenerator:


### PR DESCRIPTION
Add annotation to put the module's Grafana dashboards inside the "Disaster Recovery" folder for better organization.