### PR TITLE
Add etcd-backup-pvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are new to KFD please refer to the [official documentation][kfd-docs] on 
 
 ## Overview
 
-**Kubernetes Fury DR** module is based on [Velero][velero-page] and [Velero Node Agent][velero-node-agent-page].
+**Kubernetes Fury DR** module is based on [Velero][velero-page], [Velero Node Agent][velero-node-agent-page] and [etcd backup][etcd-backup-link].
 
 Velero allows you to:
 
@@ -25,6 +25,10 @@ Velero allows you to:
 - restore your cluster in case of problems
 - migrate cluster resources to other clusters
 - replicate your production environment to development and testing environment.
+
+ETCD backupper allows you to:
+
+- snapshot your ETCD cluster
 
 Together with Velero, Velero Node Agent allows you to:
 
@@ -42,9 +46,11 @@ The module contains also velero plugins to natively integrate with Velero with d
 
 Kubernetes Fury DR provides the following packages:
 
-| Package                  | Version  | Description                                                                                                     |
-| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------- |
-| [velero](katalog/velero) | `1.15.0` | Backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes. |
+| Package                                    | Version     | Description                                                                                                     |
+| ------------------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------- |
+| [velero](katalog/velero)                   | `1.15.0`    | Backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes. |
+| [etcd-backup-s3](katalog/etcd-backup-s3)   | `homegrown` | Backup ETCD on a remote S3 bucket.                                                                              |
+| [etcd-backup-pvc](katalog/etcd-backup-pvc) | `homegrown` | Backup ETCD on a PersistentVolumeClaim.                                                                         |
 
 The velero package contains the following additional components:
 
@@ -100,6 +106,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 | [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
 | [kustomize][kustomize-repo] | `>=3.5.3`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 | [terraform][terraform-page] | `>=1.3`    | Additional infrastructure is deployed using `terraform`.                                                                                                       |
+
 ### Velero on AWS
 
 Velero on AWS is based on the [AWS Velero Plugin][velero-aws-plugin-repo].

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ## Usage
 
-**Kubernetes Fury DR** deployment depends on the environment.
+**Kubernetes Fury DR**'s Velero deployment depends on the environment.
 
 | Environment                               | Storage Backend      | Velero Plugin                                   | Terraform Module                     |
 | ----------------------------------------- | -------------------- | ----------------------------------------------- | ------------------------------------ |
@@ -98,6 +98,13 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 | [Velero on GCP](#velero-on-gcp)           | GCS                  | [velero-gcp](katalog/velero/velero-gcp)         | [gcp-velero](modules/gcp-velero)     |
 | [Velero on Azure](#velero-on-azure)       | AZ Storage Container | [velero-azure](katalog/velero/velero-azure)     | [azure-velero](modules/azure-velero) |
 | [Velero on-premises](#velero-on-premises) | MinIo                | [velero-on-prem](katalog/velero/velero-on-prem) | `/`                                  |
+
+**Kubernetes Fury DR**'s etcd-backup deployment depends on the final location of the backups.
+| Package                                   | Storage Location        |
+| ----------------------------------------- | ----------------------- |
+| [etcd-backup-s3](#etcd-backup-s3)         | S3 Bucket               |
+| [etcd-backup-pvc](#etcd-backup-pvc)       | PersistentVolumeClaim   |
+
 
 ### Prerequisites
 
@@ -337,6 +344,14 @@ resources:
 kustomize build . | kubectl apply -f -
 ```
 
+### ETCD Backup S3
+[etcd-backup-s3][etcd-backup-s3-link] deploys a *CronJob* that continuously backups the etcd cluster and saves the snapshots in a S3 bucket.
+In order to deploy `etcd-backup-s3`, please refer to the [package's README.md][etcd-backup-s3-link].
+
+### ETCD Backup PVC
+[etcd-backup-pvc][etcd-backup-pvc-link] deploys a *CronJob* that continuously backups the etcd cluster and saves the snapshots in a PersistentVolumeClaim.
+In order to deploy `etcd-backup-pvc`, please refer to the [package's README.md][etcd-backup-pvc-link].
+
 <!-- Links -->
 
 [sighup-page]: https://sighup.io
@@ -358,6 +373,8 @@ kustomize build . | kubectl apply -f -
 [aws-docs-iam-roles]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 [kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/
 [compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-dr/blob/master/docs/COMPATIBILITY_MATRIX.md
+[etcd-backup-s3-link]: https://github.com/sighupio/fury-kubernetes-dr/blob/master/katalog/etcd-backup-s3/README.md
+[etcd-backup-pvc-link]: https://github.com/sighupio/fury-kubernetes-dr/blob/master/katalog/etcd-backup-pvc/README.md
 
 <!-- </KFD-DOCS> -->
 

--- a/katalog/etcd-backup-pvc/MAINTENANCE.md
+++ b/katalog/etcd-backup-pvc/MAINTENANCE.md
@@ -1,0 +1,24 @@
+# ETCD Backup PVC Maintenance
+
+The manifests that are present inside this package are handcrafted by us: there is no upstream to follow, apart from the `rclone` image.
+
+We're relying on the `snapshot` utility from `etcdctl`, which is basically a wrapper around a gRPC call to
+`etcd`: as long as we keep compatibility with the underlying gRPC call used by the `etcd` server, we're ok.
+
+Long story short, keep an eye on the `etcd` upstream changelog (in k8s and in `etcdctl`) for `etcd`
+gRPC API deprecations, in particular check the `Snapshot` interface.
+
+References:
+- [https://github.com/etcd-io/etcd/blob/3c916bb2587174008054f629d784514abe9e8d36/client/v3/maintenance.go#L230](client/v3/maintenance.go)
+- [https://github.com/etcd-io/etcd/blob/3c916bb2587174008054f629d784514abe9e8d36/api/etcdserverpb/rpc.pb.go#L7549](api/etcdserverpb/rpc.pb.go)
+
+The main logic of the backup and the snapshot is implemented in the `init.sh`
+file, in the [`etcd-backupper` image](https://github.com/sighupio/fury-distribution-container-image-sync/tree/main/modules/dr/custom/etcd-backupper).
+
+## Upgrade checklist
+In order to update and maintain the package:
+- First check if a new image is available for `rclone`
+- Check if another version of Alpine or `etcdctl` is available and update the [custom built `etcd-backupper` image](https://github.com/sighupio/fury-distribution-container-image-sync/tree/main/modules/dr/custom/etcd-backupper)
+- (Optional) Sync the new rclone image to our registry
+- (Optional) Update the images tags in the kustomization.yaml file
+- (Optional) Fix manifest deprecations

--- a/katalog/etcd-backup-pvc/README.md
+++ b/katalog/etcd-backup-pvc/README.md
@@ -1,0 +1,129 @@
+# ETCD Backup PVC
+
+This package provides an automated solution for backing up ETCD data to a Persistent Volume Claim present in the cluster.
+
+## Overview
+
+This package creates a CronJob that:
+
+1. Takes a snapshot of the ETCD database
+2. Copies the snapshot to a defined PersistentVolumeName
+3. Cleans up old backups based on a configurable retention policy
+
+The job is scheduled to run on one of the available control plane nodes and uses `rclone` to manage the actual backup and its lifecycle.
+
+The job is fault-tolerant, as it tries to backup the available etcd nodes:
+even if one of the etcd nodes (if you're in a HA-setup) is failing,
+`etcd-backup-pvc` asks the cluster which nodes are healthy and spashots one of
+them.
+
+> [!NOTE]
+> The job is configured to use the Host Network, as a consequence it cannot resolve service names internal to the cluster or connect to them via the internal Kubernetes network.
+
+## Requirements
+
+- A Kubernetes cluster with ETCD
+- Access to control plane nodes
+- A pre-provisioned PersistentVolumeClaim
+
+> [!NOTE]
+> By default we rely on `ClusterConfiguration` found inside the `kubeadm-config` ConfigMap to
+> extract the ETCD server endpoints. If you want to use a cluster that's not managed by
+> `kubeadm`, please make sure to remove the `kubeadm-config` volume, and pass the CronJob the
+> `ETCDCTL_ENDPOINTS` environment variable set accordingly.
+
+## Configuration
+
+### Default Configuration
+
+The package includes the following default configuration:
+
+- The backup runs on specified schedule (configurable)
+- Snapshots are stored in the format `fury-etcd-snapshot-YYYYMMDDHHMM.etcdb`
+- Backups are uploaded to the configured PersistentVolumeClaim
+- Old backups are cleaned up based on the retention policy
+
+### Components
+
+- **CronJob**: Orchestrates the backup process
+- **ConfigMaps**:
+  - `etcd-backup-config`: Contains retention settings
+  - `etcd-backup-certificates-location`: Contains ETCD connection parameters
+
+## Usage
+
+### Basic Installation
+
+1. Apply the package using kustomize:
+
+```bash
+kubectl apply -k /path/to/etcd-backup-pvc
+```
+
+### Customization
+
+To customize the package, create your own `kustomization.yaml` that references this package:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - /path/to/etcd-backup-pvc
+
+# Override configurations as needed
+patches:
+  - patch: |-
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: etcd-backup-pvc
+      spec:
+        schedule: "0 1 * * *"  # Run at 1:00 AM daily
+
+# Override configmaps
+configMapGenerator:
+  - name: etcd-backup-config
+    behavior: replace
+    literals:
+      - retention=30d  # Keep backups for 30 days
+```
+
+### Configuration Options
+
+#### Schedule
+
+You can modify the backup schedule using cron syntax:
+
+| Schedule | Description |
+|----------|-------------|
+| `0 1 * * *` | Daily at 1:00 AM |
+| `0 */6 * * *` | Every 6 hours |
+| `0 0 * * 0` | Weekly on Sunday at midnight |
+
+#### Target
+
+Backups are automatically saved at the root of the PVC volume. The name follows the following format: `fury-etcd-snapshot-YYYYMMDDHHMM.etcdb`.
+
+#### Retention
+
+Specifies how long backups should be kept before automatic deletion (follows the rclone `--min-age` format):
+
+| Value | Description |
+|-------|-------------|
+| `10d` | 10 days |
+| `1w` | 1 week |
+| `3M` | 3 months |
+
+## Security Considerations
+
+- The CronJob runs with host network access to connect to the local ETCD instance
+- It mounts the ETCD certificates from the host to authenticate and container root access is thus required
+
+## Troubleshooting
+
+Check the job logs for detailed error messages:
+
+```bash
+kubectl logs -n kube-system job/etcd-backup-pvc-<job-id> --all-containers
+```

--- a/katalog/etcd-backup-pvc/README.md
+++ b/katalog/etcd-backup-pvc/README.md
@@ -80,11 +80,20 @@ patches:
         name: etcd-backup-pvc
       spec:
         schedule: "0 1 * * *"  # Run at 1:00 AM daily
+  - patch: |-
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/volumes/2/persistentVolumeClaim/claimName
+        value: my-own-pvc
+    target:
+      group: batch
+      version: v1
+      kind: CronJob
+      name: etcd-backup-pvc
 
 # Override configmaps
 configMapGenerator:
   - name: etcd-backup-pvc-config
-    behavior: replace
+    behavior: replace # this is important, because a configMap is already defined with some defaults
     literals:
       - backup-prefix=my-custom-prefix-
       - retention=30d  # Keep backups for 30 days

--- a/katalog/etcd-backup-pvc/README.md
+++ b/katalog/etcd-backup-pvc/README.md
@@ -111,11 +111,13 @@ You can modify the backup schedule using cron syntax:
 | `0 */6 * * *` | Every 6 hours |
 | `0 0 * * 0` | Weekly on Sunday at midnight |
 
+By default, it runs every day at 1AM.
+
 #### Target
 
 Backups are automatically saved at the root of the PVC volume. The name follows the following format: `<my-custom-prefix>YYYYMMDDHHMM.etcdb`.
 
-The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-pvc-config` ConfigMap.
+The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-pvc-config` ConfigMap. By default, it's set as `my-pvc-etcd-backup-`.
 
 #### Retention
 
@@ -126,6 +128,8 @@ Specifies how long backups should be kept before automatic deletion (follows the
 | `10d` | 10 days |
 | `1w` | 1 week |
 | `3M` | 3 months |
+
+By default, it's set to `10d`.
 
 ## Security Considerations
 

--- a/katalog/etcd-backup-pvc/README.md
+++ b/katalog/etcd-backup-pvc/README.md
@@ -39,7 +39,7 @@ them.
 The package includes the following default configuration:
 
 - The backup runs on specified schedule (configurable)
-- Snapshots are stored in the format `fury-etcd-snapshot-YYYYMMDDHHMM.etcdb`
+- Snapshots are stored in the format `<my-custom-prefix>YYYYMMDDHHMM.etcdb`, the prefix is configurable by the user, using `kustomize`.
 - Backups are uploaded to the configured PersistentVolumeClaim
 - Old backups are cleaned up based on the retention policy
 
@@ -47,8 +47,8 @@ The package includes the following default configuration:
 
 - **CronJob**: Orchestrates the backup process
 - **ConfigMaps**:
-  - `etcd-backup-config`: Contains retention settings
-  - `etcd-backup-certificates-location`: Contains ETCD connection parameters
+  - `etcd-backup-pvc-config`: Contains retention settings and the prefix to be used for the backup names
+  - `etcd-backup-pvc-certificates-location`: Contains ETCD connection parameters
 
 ## Usage
 
@@ -83,9 +83,10 @@ patches:
 
 # Override configmaps
 configMapGenerator:
-  - name: etcd-backup-config
+  - name: etcd-backup-pvc-config
     behavior: replace
     literals:
+      - backup-prefix=my-custom-prefix-
       - retention=30d  # Keep backups for 30 days
 ```
 
@@ -103,7 +104,9 @@ You can modify the backup schedule using cron syntax:
 
 #### Target
 
-Backups are automatically saved at the root of the PVC volume. The name follows the following format: `fury-etcd-snapshot-YYYYMMDDHHMM.etcdb`.
+Backups are automatically saved at the root of the PVC volume. The name follows the following format: `<my-custom-prefix>YYYYMMDDHHMM.etcdb`.
+
+The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-pvc-config` ConfigMap.
 
 #### Retention
 

--- a/katalog/etcd-backup-pvc/cronjob.yaml
+++ b/katalog/etcd-backup-pvc/cronjob.yaml
@@ -1,0 +1,108 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-backup-pvc
+  labels:
+    app.kubernetes.io/name: etcd-backup-pvc
+    app.kubernetes.io/instance: etcd-backup-pvc-dr
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: disaster-recovery
+    app.kubernetes.io/part-of: KFD
+spec:
+  schedule: "* * 2 * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          namespace: kube-system
+          labels:
+            app.kubernetes.io/name: etcd-backup-pvc
+            app.kubernetes.io/instance: etcd-backup-pvc-dr
+            app.kubernetes.io/version: "1.0.0"
+            app.kubernetes.io/component: disaster-recovery
+            app.kubernetes.io/part-of: KFD
+        spec:
+          volumes:
+            - name: etcd-certs
+              hostPath:
+                path: /etc/etcd/pki
+            - name: persistence
+              emptyDir: {}
+            - name: kubeadm-config
+              configMap:
+                name: kubeadm-config
+                items:
+                - key: ClusterConfiguration
+                  path: config.yaml
+            - name: target-pvc
+              persistentVolumeClaim:
+                claimName: target-pvc
+          initContainers:
+            - name: backupper
+              image: etcd-backupper
+              envFrom:
+                - configMapRef:
+                    name: etcd-backup-certificates-location
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+              volumeMounts:
+                - mountPath: /etcd
+                  name: etcd-certs
+                  readOnly: true
+                - mountPath: /backup
+                  name: persistence
+                - mountPath: /k8s
+                  name: kubeadm-config
+            - name: move-to-pvc
+              image: rclone
+              command:
+                - "/bin/sh"
+                - "-c"
+              args:
+                - 'rclone copy /etcd-backup /target'
+              volumeMounts:
+                - mountPath: /etcd-backup
+                  name: persistence
+                - mountPath: /target
+                  name: target-pvc
+          containers:
+            - name: delete-old
+              image: rclone
+              command:
+                - "/bin/sh"
+                - "-c"
+              args:
+                - 'rclone delete /target --min-age="$RETENTION" --include=fury-etcd-snapshot*.etcdb'
+              env:
+                - name: RETENTION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: etcd-backup-config
+                      key: retention
+              volumeMounts:
+                - mountPath: /target
+                  name: target-pvc
+          restartPolicy: OnFailure
+          hostNetwork: true
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              effect: NoSchedule
+              operator: Exists
+            - key: node.kubernetes.io/memory-pressure
+              effect: NoSchedule
+              operator: Exists

--- a/katalog/etcd-backup-pvc/cronjob.yaml
+++ b/katalog/etcd-backup-pvc/cronjob.yaml
@@ -49,7 +49,7 @@ spec:
               image: etcd-backupper
               envFrom:
                 - configMapRef:
-                    name: etcd-backup-certificates-location
+                    name: etcd-backup-pvc-certificates-location
               securityContext:
                 runAsUser: 0
                 runAsGroup: 0

--- a/katalog/etcd-backup-pvc/cronjob.yaml
+++ b/katalog/etcd-backup-pvc/cronjob.yaml
@@ -57,21 +57,9 @@ spec:
                 - mountPath: /etcd
                   name: etcd-certs
                   readOnly: true
-                - mountPath: /backup
-                  name: persistence
                 - mountPath: /k8s
                   name: kubeadm-config
-            - name: move-to-pvc
-              image: rclone
-              command:
-                - "/bin/sh"
-                - "-c"
-              args:
-                - 'rclone copy /etcd-backup /target'
-              volumeMounts:
-                - mountPath: /etcd-backup
-                  name: persistence
-                - mountPath: /target
+                - mountPath: /backup
                   name: target-pvc
           containers:
             - name: delete-old
@@ -85,7 +73,7 @@ spec:
                 - name: RETENTION
                   valueFrom:
                     configMapKeyRef:
-                      name: etcd-backup-config
+                      name: etcd-backup-pvc-config
                       key: retention
               volumeMounts:
                 - mountPath: /target

--- a/katalog/etcd-backup-pvc/cronjob.yaml
+++ b/katalog/etcd-backup-pvc/cronjob.yaml
@@ -37,8 +37,8 @@ spec:
               configMap:
                 name: kubeadm-config
                 items:
-                - key: ClusterConfiguration
-                  path: config.yaml
+                  - key: ClusterConfiguration
+                    path: config.yaml
             - name: target-pvc
               persistentVolumeClaim:
                 claimName: target-pvc

--- a/katalog/etcd-backup-pvc/cronjob.yaml
+++ b/katalog/etcd-backup-pvc/cronjob.yaml
@@ -59,6 +59,12 @@ spec:
                   name: kubeadm-config
                 - mountPath: /backup
                   name: target-pvc
+              env:
+                - name: BACKUP_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: etcd-backup-pvc-config
+                      key: backup-prefix
           containers:
             - name: delete-old
               image: rclone
@@ -66,13 +72,18 @@ spec:
                 - "/bin/sh"
                 - "-c"
               args:
-                - 'rclone delete /target --min-age="$RETENTION" --include=fury-etcd-snapshot*.etcdb'
+                - 'rclone delete /target --min-age="$RETENTION" --include="${BACKUP_PREFIX}*.etcdb"'
               env:
                 - name: RETENTION
                   valueFrom:
                     configMapKeyRef:
                       name: etcd-backup-pvc-config
                       key: retention
+                - name: BACKUP_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: etcd-backup-pvc-config
+                      key: backup-prefix
               volumeMounts:
                 - mountPath: /target
                   name: target-pvc

--- a/katalog/etcd-backup-pvc/cronjob.yaml
+++ b/katalog/etcd-backup-pvc/cronjob.yaml
@@ -33,8 +33,6 @@ spec:
             - name: etcd-certs
               hostPath:
                 path: /etc/etcd/pki
-            - name: persistence
-              emptyDir: {}
             - name: kubeadm-config
               configMap:
                 name: kubeadm-config

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -5,8 +5,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kube-system
-
 resources:
   - cronjob.yaml
 
@@ -17,24 +15,6 @@ images:
   - name: rclone
     newName: registry.sighup.io/fury/dr/etcd-backup/rclone
     newTag: v1.69-stable
-
-patches:
-  - patch: |-
-      apiVersion: batch/v1
-      kind: CronJob
-      metadata:
-        name: etcd-backup-pvc
-      spec:
-        schedule: "* * * * *"
-  - patch: |-
-      - op: replace
-        path: /spec/jobTemplate/spec/template/spec/volumes/2/persistentVolumeClaim/claimName
-        value: test
-    target:
-      group: batch
-      version: v1
-      kind: CronJob
-      name: etcd-backup-pvc
 
 configMapGenerator:
   - name: etcd-backup-pvc-config

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -5,6 +5,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kube-system
+
 resources:
   - cronjob.yaml
 

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -31,7 +31,7 @@ configMapGenerator:
   - name: etcd-backup-pvc-config
     literals:
       - retention=10m
-  - name: etcd-backup-certificates-location
+  - name: etcd-backup-pvc-certificates-location
     literals:
       - ETCDCTL_CACERT=/etcd/etcd/ca.crt
       - ETCDCTL_CERT=/etcd/apiserver-etcd-client.crt

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-system
+
+resources:
+  - cronjob.yaml
+
+images:
+  - name: etcd-backupper
+    newName: registry.sighup.io/fury/dr/etcd-backup/etcd-backupper
+    newTag: alpine3.21-v3.5.19
+  - name: rclone
+    newName: registry.sighup.io/fury/dr/etcd-backup/rclone
+    newTag: v1.69-stable
+
+patches:
+  - patch: |-
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: etcd-backup-pvc
+      spec:
+        schedule: "* * * * *"
+
+configMapGenerator:
+  - name: etcd-backup-config
+    literals:
+      - retention=10m
+  - name: etcd-backup-certificates-location
+    literals:
+      - ETCDCTL_CACERT=/etcd/etcd/ca.crt
+      - ETCDCTL_CERT=/etcd/apiserver-etcd-client.crt
+      - ETCDCTL_KEY=/etcd/apiserver-etcd-client.key

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -26,6 +26,15 @@ patches:
         name: etcd-backup-pvc
       spec:
         schedule: "* * * * *"
+  - patch: |-
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/volumes/2/persistentVolumeClaim/claimName
+        value: test
+    target:
+      group: batch
+      version: v1
+      kind: CronJob
+      name: etcd-backup-pvc
 
 configMapGenerator:
   - name: etcd-backup-pvc-config

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
   - name: etcd-backup-pvc-config
     literals:
       - retention=10m
+      - backup-prefix=my-etcd-backup-
   - name: etcd-backup-pvc-certificates-location
     literals:
       - ETCDCTL_CACERT=/etcd/etcd/ca.crt

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -28,7 +28,7 @@ patches:
         schedule: "* * * * *"
 
 configMapGenerator:
-  - name: etcd-backup-config
+  - name: etcd-backup-pvc-config
     literals:
       - retention=10m
   - name: etcd-backup-certificates-location

--- a/katalog/etcd-backup-pvc/kustomization.yaml
+++ b/katalog/etcd-backup-pvc/kustomization.yaml
@@ -19,8 +19,8 @@ images:
 configMapGenerator:
   - name: etcd-backup-pvc-config
     literals:
-      - retention=10m
-      - backup-prefix=my-etcd-backup-
+      - retention=10d
+      - backup-prefix=my-pvc-etcd-backup-
   - name: etcd-backup-pvc-certificates-location
     literals:
       - ETCDCTL_CACERT=/etcd/etcd/ca.crt

--- a/katalog/etcd-backup-s3/README.md
+++ b/katalog/etcd-backup-s3/README.md
@@ -88,7 +88,7 @@ patches:
 # Override configmaps
 configMapGenerator:
   - name: etcd-backup-s3-config
-    behavior: replace
+    behavior: replace # this is important, because a configMap is already defined with some defaults
     literals:
       - backup-prefix=my-custom-prefix-
       - target=s3:your-bucket-name/backups # `s3` must match with the section name in rclone.conf

--- a/katalog/etcd-backup-s3/README.md
+++ b/katalog/etcd-backup-s3/README.md
@@ -107,17 +107,17 @@ You can modify the backup schedule using cron syntax:
 | `0 */6 * * *` | Every 6 hours |
 | `0 0 * * 0` | Weekly on Sunday at midnight |
 
+By default it runs every day at 1AM.
+
 #### Target
 
-The S3 target follows the rclone format: `provider:bucket-name/path`.
+The S3 target follows the rclone format: `provider:bucket-name/path`. By default it's: `minio:bucketname`.
 
 The name follows the following format: `<my-custom-prefix>YYYYMMDDHHMM.etcdb`.
 
-The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-s3-config` ConfigMap.
+The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-s3-config` ConfigMap. By default it's set to `my-s3-etcd-backup-`.
 
 The `provider` is defined in the `rclone.conf` file, name in the target must match the name of the section in the configuration file.
-
-The `prefix` is defined inside the `etcd-backup-s3-config` ConfigMap.
 
 #### Retention
 
@@ -128,6 +128,8 @@ Specifies how long backups should be kept before automatic deletion (follows the
 | `10d` | 10 days |
 | `1w` | 1 week |
 | `3M` | 3 months |
+
+By default, it's set to `10d`.
 
 ## Security Considerations
 

--- a/katalog/etcd-backup-s3/README.md
+++ b/katalog/etcd-backup-s3/README.md
@@ -40,7 +40,7 @@ them.
 The package includes the following default configuration:
 
 - The backup runs on specified schedule (configurable)
-- Snapshots are stored in the format `fury-etcd-snapshot-YYYYMMDDHHMM.etcdb`
+- Snapshots are stored in the format `<my-custom-prefix>YYYYMMDDHHMM.etcdb`, the prefix is configurable by the user, using `kustomize`.
 - Backups are uploaded to the configured S3 target
 - Old backups are cleaned up based on the retention policy
 
@@ -48,8 +48,8 @@ The package includes the following default configuration:
 
 - **CronJob**: Orchestrates the backup process
 - **ConfigMaps**:
-  - `etcd-backup-s3-config`: Contains S3 target and retention settings
-  - `etcd-backup-certificates-location`: Contains ETCD connection parameters
+  - `etcd-backup-s3-config`: Contains S3 target, retention settings and the backup name prefix
+  - `etcd-backup-s3-certificates-location`: Contains ETCD connection parameters
 - **Secret**:
   - `etcd-backup-s3-rclone-conf`: Contains the rclone configuration
 
@@ -90,6 +90,7 @@ configMapGenerator:
   - name: etcd-backup-s3-config
     behavior: replace
     literals:
+      - backup-prefix=my-custom-prefix-
       - target=s3:your-bucket-name/backups # `s3` must match with the section name in rclone.conf
       - retention=30d  # Keep backups for 30 days
 ```
@@ -110,7 +111,13 @@ You can modify the backup schedule using cron syntax:
 
 The S3 target follows the rclone format: `provider:bucket-name/path`.
 
+The name follows the following format: `<my-custom-prefix>YYYYMMDDHHMM.etcdb`.
+
+The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-s3-config` ConfigMap.
+
 The `provider` is defined in the `rclone.conf` file, name in the target must match the name of the section in the configuration file.
+
+The `prefix` is defined inside the `etcd-backup-s3-config` ConfigMap.
 
 #### Retention
 

--- a/katalog/etcd-backup-s3/cronjob.yaml
+++ b/katalog/etcd-backup-s3/cronjob.yaml
@@ -49,6 +49,12 @@ spec:
               envFrom:
                 - configMapRef:
                     name: etcd-backup-s3-certificates-location
+              env:
+                - name: BACKUP_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: etcd-backup-s3-config
+                      key: backup-prefix
               securityContext:
                 runAsUser: 0
                 runAsGroup: 0
@@ -86,7 +92,7 @@ spec:
                 - "/bin/sh"
                 - "-c"
               args:
-                - 'rclone delete "$TARGET" --min-age="$RETENTION" --include=fury-etcd-snapshot*.etcdb'
+                - 'rclone delete "$TARGET" --min-age="$RETENTION" --include="${BACKUP_PREFIX}*.etcdb"'
               env:
                 - name: TARGET
                   valueFrom:
@@ -98,6 +104,11 @@ spec:
                     configMapKeyRef:
                       name: etcd-backup-s3-config
                       key: retention
+                - name: BACKUP_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: etcd-backup-s3-config
+                      key: backup-prefix
               volumeMounts:
                 - mountPath: /config/rclone
                   name: etcd-backup-s3-rclone-conf

--- a/katalog/etcd-backup-s3/cronjob.yaml
+++ b/katalog/etcd-backup-s3/cronjob.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: disaster-recovery
     app.kubernetes.io/part-of: KFD
 spec:
-  schedule: "* * 2 * *"
+  schedule: "0 1 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
   concurrencyPolicy: Forbid
@@ -21,12 +21,12 @@ spec:
     spec:
       template:
         metadata:
-            labels:
-              app.kubernetes.io/name: etcd-backup-s3
-              app.kubernetes.io/instance: etcd-backup-s3-dr
-              app.kubernetes.io/version: "1.0.0"
-              app.kubernetes.io/component: disaster-recovery
-              app.kubernetes.io/part-of: KFD
+          labels:
+            app.kubernetes.io/name: etcd-backup-s3
+            app.kubernetes.io/instance: etcd-backup-s3-dr
+            app.kubernetes.io/version: "1.0.0"
+            app.kubernetes.io/component: disaster-recovery
+            app.kubernetes.io/part-of: KFD
         spec:
           volumes:
             - name: etcd-certs
@@ -38,8 +38,8 @@ spec:
               configMap:
                 name: kubeadm-config
                 items:
-                - key: ClusterConfiguration
-                  path: config.yaml
+                  - key: ClusterConfiguration
+                    path: config.yaml
             - name: etcd-backup-s3-rclone-conf
               secret:
                 secretName: etcd-backup-s3-rclone-conf

--- a/katalog/etcd-backup-s3/cronjob.yaml
+++ b/katalog/etcd-backup-s3/cronjob.yaml
@@ -48,7 +48,7 @@ spec:
               image: etcd-backupper
               envFrom:
                 - configMapRef:
-                    name: etcd-backup-certificates-location
+                    name: etcd-backup-s3-certificates-location
               securityContext:
                 runAsUser: 0
                 runAsGroup: 0

--- a/katalog/etcd-backup-s3/kustomization.yaml
+++ b/katalog/etcd-backup-s3/kustomization.yaml
@@ -5,8 +5,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kube-system
-
 resources:
   - cronjob.yaml
 
@@ -17,15 +15,6 @@ images:
   - name: rclone
     newName: registry.sighup.io/fury/dr/etcd-backup/rclone
     newTag: v1.69-stable
-
-patches:
-  - patch: |-
-      apiVersion: batch/v1
-      kind: CronJob
-      metadata:
-        name: etcd-backup-s3
-      spec:
-        schedule: "* * 1 * *"
 
 configMapGenerator:
   - name: etcd-backup-s3-config

--- a/katalog/etcd-backup-s3/kustomization.yaml
+++ b/katalog/etcd-backup-s3/kustomization.yaml
@@ -5,6 +5,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kube-system
+
 resources:
   - cronjob.yaml
 

--- a/katalog/etcd-backup-s3/kustomization.yaml
+++ b/katalog/etcd-backup-s3/kustomization.yaml
@@ -32,7 +32,7 @@ configMapGenerator:
     literals:
       - target=minio:bucketname
       - retention=10m
-  - name: etcd-backup-certificates-location
+  - name: etcd-backup-s3-certificates-location
     literals:
       - ETCDCTL_CACERT=/etcd/etcd/ca.crt
       - ETCDCTL_CERT=/etcd/apiserver-etcd-client.crt

--- a/katalog/etcd-backup-s3/kustomization.yaml
+++ b/katalog/etcd-backup-s3/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
   - name: etcd-backup-s3-config
     literals:
       - target=minio:bucketname
-      - retention=10m
+      - retention=10d
       - backup-prefix=my-s3-etcd-backup-
   - name: etcd-backup-s3-certificates-location
     literals:

--- a/katalog/etcd-backup-s3/kustomization.yaml
+++ b/katalog/etcd-backup-s3/kustomization.yaml
@@ -32,6 +32,7 @@ configMapGenerator:
     literals:
       - target=minio:bucketname
       - retention=10m
+      - backup-prefix=my-s3-etcd-backup-
   - name: etcd-backup-s3-certificates-location
     literals:
       - ETCDCTL_CACERT=/etcd/etcd/ca.crt


### PR DESCRIPTION
### Summary 💡
This PR adds support for saving ETCD snapshots to an existing PersistentVolumeClaim.

Relates: https://github.com/sighupio/product-management/issues/638

### Description 📝
This feature allows users to backup the ETCD database to an existing in-cluster PersistentVolumeClaim.

### Breaking Changes 💔

Hopefully nothing 🙈

### Tests performed 🧪

- [x] Tested the change with a PersistentVolumeClaim backed by an `hostPath` volume

### Future work 🔧
Add more backends.
