### PR TITLE
fix(etcd-backup): exclude etcd-backup pods from Velero backups

### DIFF
--- a/docs/releases/v3.3.0.md
+++ b/docs/releases/v3.3.0.md
@@ -25,6 +25,10 @@ This latest release upgrades the components in the module to their latest stable
 - Update plugins
 - Add `node-agent-config` configmap and `--node-agent-configmap` argument to the node-agent daemonset to support Velero's [`prepareQueueLength`](https://velero.io/docs/v1.17/node-agent-prepare-queue-length/) configuration.
 
+## Bug Fixes 🐛
+
+- Exclude etcd-backup-s3, etcd-backup-pvc pods and jobs from Velero backups.
+
 ## Breaking Changes 💔
 
 > [!WARNING]

--- a/katalog/etcd-backup-pvc/cronjob.yaml
+++ b/katalog/etcd-backup-pvc/cronjob.yaml
@@ -18,6 +18,9 @@ spec:
   failedJobsHistoryLimit: 5
   concurrencyPolicy: Forbid
   jobTemplate:
+    metadata:
+      labels:
+        velero.io/exclude-from-backup: "true"
     spec:
       template:
         metadata:
@@ -28,6 +31,7 @@ spec:
             app.kubernetes.io/version: "1.0.0"
             app.kubernetes.io/component: disaster-recovery
             app.kubernetes.io/part-of: KFD
+            velero.io/exclude-from-backup: "true"
         spec:
           volumes:
             - name: etcd-certs

--- a/katalog/etcd-backup-s3/cronjob.yaml
+++ b/katalog/etcd-backup-s3/cronjob.yaml
@@ -18,6 +18,9 @@ spec:
   failedJobsHistoryLimit: 5
   concurrencyPolicy: Forbid
   jobTemplate:
+    metadata:
+      labels:
+        velero.io/exclude-from-backup: "true"
     spec:
       template:
         metadata:
@@ -27,6 +30,7 @@ spec:
             app.kubernetes.io/version: "1.0.0"
             app.kubernetes.io/component: disaster-recovery
             app.kubernetes.io/part-of: KFD
+            velero.io/exclude-from-backup: "true"
         spec:
           volumes:
             - name: etcd-certs


### PR DESCRIPTION
### Summary 💡

Exclude etcd-backup pods and jobs from Velero backups.

Closes: #95

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Executed an apply with furyctl pointing to this branch with success
- It will be extensively tested during the distro's e2e tests prior to release.
