### PR TITLE
docs: refactor module documentation, drop legacy Furyfile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,37 +15,19 @@
 
 <!-- <SD-DOCS> -->
 
-**Disaster Recovery Module** implements backups and disaster recovery for the [SIGHUP Distribution (SD)][skd-repo] using [Velero][velero-page].
+**Disaster Recovery Module** implements backups and disaster recovery for [SIGHUP Distribution (SD)][kfd-repo].
 
-If you are new to SD please refer to the [official documentation][skd-docs] on how to get started with SD.
+If you are new to SD please refer to the [official documentation][kfd-docs] on how to get started with SD.
 
 ## Overview
 
-**Disaster Recovery Module** module is based on [Velero][velero-page], [Velero Node Agent][velero-node-agent-page] and etcd backup ([S3][etcd-backup-s3-link]/[PVC][etcd-backup-pvc-link]).
+**Disaster Recovery Module** is based on [Velero][velero-page] (with [Velero Node Agent][velero-node-agent-page] for volume backups) and on etcd backups.
 
-Velero allows you to:
+Velero allows you to back up and restore your cluster resources and persistent volumes, migrate resources between clusters, and replicate your production environment to development and testing environments. When the [`snapshot-controller`](katalog/velero/snapshot-controller) is enabled, [CSI Snapshot Data Movement][csi-data-movement] provides consistent backups of volume data to a backup storage location.
 
-- backup your cluster
-- restore your cluster in case of problems
-- migrate cluster resources to other clusters
-- replicate your production environment to development and testing environment.
+The etcd backup packages snapshot the cluster's etcd database to an S3 bucket or to a PersistentVolumeClaim, on self-managed clusters where you control etcd.
 
-ETCD backup allows you to:
-
-- snapshot your ETCD cluster on an S3 bucket
-- snapshot your ETCD cluster on an already provisioned PVC
-
-Together with Velero, Velero Node Agent allows you to:
-
-- backup Kubernetes volumes
-- restore Kubernetes volumes
-
-And by using the [`snapshot-controller`](../../katalog/velero/snapshot-controller/README.md), the support for [CSI Snapshot Data Movement](https://velero.io/docs/main/csi-snapshot-data-movement/) can be enabled, which allows you to:
-
-- backup the volume data to a pre-defined backup storage
-- have **consistent** backups of your data
-
-The module contains also velero plugins to natively integrate with Velero with different cloud providers and use cloud provider's volumes as the storage backend.
+The module also includes Velero plugins to integrate natively with different cloud providers and use their object storage as the backup backend.
 
 ## Packages
 
@@ -53,34 +35,32 @@ Disaster Recovery Module provides the following packages:
 
 | Package                                    | Version     | Description                                                                                                     |
 | ------------------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------- |
-| [velero](katalog/velero)                   | `v1.18.1`    | Backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes. |
-| [etcd-backup-s3](katalog/etcd-backup-s3)   | `homegrown` | Backup ETCD on a remote S3 bucket.                                                                              |
-| [etcd-backup-pvc](katalog/etcd-backup-pvc) | `homegrown` | Backup ETCD on a PersistentVolumeClaim.                                                                         |
+| [velero](katalog/velero)                   | `v1.18.1`   | Backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes. |
+| [etcd-backup-s3](katalog/etcd-backup-s3)   | `homegrown` | Backup etcd on a remote S3 bucket.                                                                              |
+| [etcd-backup-pvc](katalog/etcd-backup-pvc) | `homegrown` | Backup etcd on a PersistentVolumeClaim.                                                                         |
 
 The velero package contains the following additional components:
 
-| Component                                           | Description                                           |
-| --------------------------------------------------- | ----------------------------------------------------- |
-| [velero-node-agent](katalog/velero/velero-node-agent)       | Incremental backup and restore of Kubernetes volumes. |
-| [velero-schedules](katalog/velero/velero-schedules) | Common schedules for backup                           |
+| Component                                                   | Description                                                            |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [velero-base](katalog/velero/velero-base)                   | Common Velero components shared by all backends.                       |
+| [velero-node-agent](katalog/velero/velero-node-agent)       | Incremental backup and restore of Kubernetes volumes.                  |
+| [velero-schedules](katalog/velero/velero-schedules)         | Common schedules for backup.                                           |
+| [snapshot-controller](katalog/velero/snapshot-controller)   | Enables CSI Snapshot Data Movement support.                            |
+| [velero-aws](katalog/velero/velero-aws)                     | Plugin to support running Velero on AWS.                               |
+| [velero-gcp](katalog/velero/velero-gcp)                     | Plugin to support running Velero on GCP.                               |
+| [velero-azure](katalog/velero/velero-azure)                 | Plugin to support running Velero on Azure.                             |
+| [velero-on-prem](katalog/velero/velero-on-prem)             | In-cluster MinIO object storage backend for on-premises clusters.      |
 
-### Integration with cloud providers
-
-Use the following Velero Plugins to integrate Velero with cloud providers:
-
-| Plugin                                      | Description                                |
-| ------------------------------------------- | ------------------------------------------ |
-| [velero-aws](katalog/velero/velero-aws)     | Plugins to support running Velero on AWS   |
-| [velero-gcp](katalog/velero/velero-gcp)     | Plugins to support running Velero on GCP   |
-| [velero-azure](katalog/velero/velero-azure) | Plugins to support running Velero on Azure |
-
-Deploy the necessary infrastructure to persist the backups natively in cloud providers volumes, using the following terraform modules:
+The following Terraform modules provision the cloud infrastructure used to persist the backups natively in cloud providers' object storage:
 
 | Terraform Module                     | Description                                                     |
 | ------------------------------------ | --------------------------------------------------------------- |
 | [aws-velero](modules/aws-velero)     | Creates AWS resources and Kubernetes CRDs to persist backups.   |
 | [azure-velero](modules/azure-velero) | Creates Azure resources and Kubernetes CRDs to persist backups. |
 | [gcp-velero](modules/gcp-velero)     | Creates GCP resources and Kubernetes CRDs to persist backups.   |
+
+Click on each package to see its full documentation.
 
 ## Compatibility
 
@@ -94,298 +74,49 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ## Usage
 
-**Disaster Recovery Module**'s Velero deployment depends on the environment.
+**Disaster Recovery Module** is part of SIGHUP Distribution (SD) and is deployed automatically by [`furyctl`][furyctl-repo] when you create or update a cluster. You don't need to download, vendor or install its packages manually.
 
-| Environment                               | Storage Backend      | Velero Plugin                                   | Terraform Module                     |
-| ----------------------------------------- | -------------------- | ----------------------------------------------- | ------------------------------------ |
-| [Velero on AWS](#velero-on-aws)           | S3 Bucket            | [velero-aws](katalog/velero/velero-aws)         | [aws-velero](modules/aws-velero)     |
-| [Velero on GCP](#velero-on-gcp)           | GCS                  | [velero-gcp](katalog/velero/velero-gcp)         | [gcp-velero](modules/gcp-velero)     |
-| [Velero on Azure](#velero-on-azure)       | AZ Storage Container | [velero-azure](katalog/velero/velero-azure)     | [azure-velero](modules/azure-velero) |
-| [Velero on-premises](#velero-on-premises) | MinIo                | [velero-on-prem](katalog/velero/velero-on-prem) | `/`                                  |
+### Configuration
 
-**Disaster Recovery Module**'s etcd-backup deployment depends on the final location of the backups.
-| Package                                   | Storage Location        |
-| ----------------------------------------- | ----------------------- |
-| [etcd-backup-s3](#etcd-backup-s3)         | S3 Bucket               |
-| [etcd-backup-pvc](#etcd-backup-pvc)       | PersistentVolumeClaim   |
-
-
-### Prerequisites
-
-| Tool                        | Version    | Description                                                                                                                                                    |
-| --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
-| [kustomize][kustomize-repo] | `>=3.5.3`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
-| [terraform][terraform-page] | `>=1.3`    | Additional infrastructure is deployed using `terraform`.                                                                                                       |
-
-### Velero on AWS
-
-Velero on AWS is based on the [AWS Velero Plugin][velero-aws-plugin-repo].
-
-It requires the secret `cloud-credentials` in the `kube-system` namespace containing a service account with appropriate credentials.
-As an alternative, the module supports [authentication via IAM Roles][aws-docs-iam-roles].
-
-To deploy Velero on AWS:
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
+You configure the module under `spec.distribution.modules.dr` in your `furyctl.yaml`. The `type` field selects whether disaster recovery is enabled: `none` to disable it, or the value matching your cluster kind — `eks` on `EKSCluster`, `on-premises` on `KFDDistribution` and `OnPremises`. The `velero.backend` field selects the storage backend for the backups (`minio`, `externalEndpoint` or `gcs`). The other fields are optional and fall back to sensible defaults.
 
 ```yaml
-bases:
-  - name: dr/velero/velero-base
-    version: "v3.4.0"
-  - name: dr/velero/velero-aws
-    version: "v3.4.0"
-  - name: dr/velero/velero-node-agent
-    version: "v3.4.0"
-  - name: dr/velero/velero-schedules
-    version: "v3.4.0"
-
-modules:
-  - name: dr/aws-velero
-    version: "v3.4.0"
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      dr:
+        type: on-premises
+        velero:
+          backend: minio
 ```
 
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
+See the configuration reference for your cluster kind for the full list of available options: [EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd] or [OnPremises][schema-reference-onprem].
 
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the downloaded packages under `./vendor/katalog/velero`.
-
-4. Deploy the necessary infrastructure via terraform using the `aws-velero` terraform module:
-
-```hcl
-module "velero" {
-  source             = "path/to/vendor/modules/aws-velero"
-  backup_bucket_name = "my-cluster-velero"
-  project            = "sighup-staging"
-}
-```
-
-> More information on modules inputs can be found in the [aws-velero](modules/aws-velero) module documentation
->
-> [Here][skd-velero-aws-example] you can find an example designed to create all necessary cloud resources for Velero on AWS.
-
-5. Define a `kustomization.yaml` that includes the downloaded resources.
-
-```yaml
-resources:
-  - ./vendor/katalog/dr/velero/velero-aws
-  - ./vendor/katalog/dr/velero/velero-node-agent
-  - ./vendor/katalog/dr/velero/velero-schedules
-```
-
-6. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-### Velero on GCP
-
-Velero on GCP is based on the [Velero GCP Plugin][velero-gcp-plugin-repo].
-
-It requires the secret `cloud-credentials` in the `kube-system` namespace containing a service account with appropriate credentials.
-As an alternative, the module supports workload identity.
-
-> Check the required Velero GCP plugin permissions [here][velero-gcp-plugin-repo-permissions]
-
-To deploy Velero on GCP:
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
-
-```yaml
-bases:
-  - name: dr/velero/velero-base
-    version: "v3.4.0"
-  - name: dr/velero/velero-gcp
-    version: "v3.4.0"
-  - name: dr/velero/velero-node-agent
-    version: "v3.4.0"
-  - name: dr/velero/velero-schedules
-    version: "v3.4.0"
-
-modules:
-  - name: dr/gcp-velero
-    version: "v3.4.0"
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the downloaded packages under `./vendor/katalog/velero`.
-
-4. Deploy the necessary infrastructure via terraform using the `gcp-velero` terraform module:
-
-```hcl
-module "velero" {
-  source             = "path/to/vendor/modules/gcp-velero"
-  backup_bucket_name = "my-cluster-velero"
-  project            = "sighup-staging"
-}
-```
-
-> More information on modules inputs can be found in the [gcp-velero](modules/gcp-velero) module documentation
->
-> [Here][skd-velero-gcp-example] you can find an example designed to create all necessary cloud resources for Velero on GCP.
-
-5. Define a `kustomization.yaml` that includes the downloaded resources.
-
-```yaml
-resources:
-  - ./vendor/katalog/dr/velero/velero-gcp
-  - ./vendor/katalog/dr/velero/velero-node-agent
-  - ./vendor/katalog/dr/velero/velero-schedules
-```
-
-6. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-### Velero on Azure
-
-Velero on Azure is based on the [Azure Velero Plugin][velero-azure-plugin-repo].
-
-Requires the `cloud-credentials` `secret` config in the `kube-system` namespace.
-
-To deploy Velero on Azure:
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
-
-```yaml
-bases:
-  - name: dr/velero/velero-base
-    version: "v3.4.0"
-  - name: dr/velero/velero-azure
-    version: "v3.4.0"
-  - name: dr/velero/velero-node-agent
-    version: "v3.4.0"
-  - name: dr/velero/velero-schedules
-    version: "v3.4.0"
-
-modules:
-  - name: dr/azure-velero
-    version: "v3.4.0"
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the downloaded packages under `./vendor/katalog/velero`.
-
-4. Deploy the necessary infrastructure via terraform using the `azure-velero` terraform module:
-
-```hcl
-module "velero" {
-  source             = "path/to/vendor/modules/azure-velero"
-  backup_bucket_name = "my-cluster-velero"
-  project            = "sighup-staging"
-}
-```
-
-> More information on modules inputs can be found in the [azure-velero](modules/azure-velero) module documentation
->
-> [Here][skd-velero-azure-example] you can find an example designed to create all necessary cloud resources for Velero on Azure.
-
-5. Define a `kustomization.yaml` that includes the downloaded resources.
-
-```yaml
-resources:
-  - ./vendor/katalog/dr/velero/velero-azure
-  - ./vendor/katalog/dr/velero/velero-node-agent
-  - ./vendor/katalog/dr/velero/velero-schedules
-```
-
-6. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-### Velero on-premises
-
-[velero-on-prem][skd-velero-on-prem] deploys a [MinIO][minio-page] in-cluster instance as an object storage backend for Velero.
-
-Please note that the MinIO server is running in the same cluster that is being backed up.
-
-To deploy `velero on-prem`:
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
-
-```yaml
-bases:
-  - name: dr/velero/velero-base
-    version: "v3.4.0"
-  - name: dr/velero/velero-on-prem
-    version: "v3.4.0"
-  - name: dr/velero/velero-node-agent
-    version: "v3.4.0"
-  - name: dr/velero/velero-schedules
-    version: "v3.4.0"
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the downloaded packages under `./vendor/katalog/velero`.
-
-4. Define a `kustomization.yaml` that includes the downloaded resources.
-
-```yaml
-resources:
-  - ./vendor/katalog/dr/velero/velero-on-prem
-  - ./vendor/katalog/dr/velero/velero-node-agent
-  - ./vendor/katalog/dr/velero/velero-schedules
-```
-
-5. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-### ETCD Backup S3
-[etcd-backup-s3][etcd-backup-s3-link] deploys a *CronJob* that continuously backups the etcd cluster and saves the snapshots in a S3 bucket.
-In order to deploy `etcd-backup-s3`, please refer to the [package's README.md][etcd-backup-s3-link].
-
-### ETCD Backup PVC
-[etcd-backup-pvc][etcd-backup-pvc-link] deploys a *CronJob* that continuously backups the etcd cluster and saves the snapshots in a PersistentVolumeClaim.
-In order to deploy `etcd-backup-pvc`, please refer to the [package's README.md][etcd-backup-pvc-link].
+To install SD from scratch, follow the [Getting started][getting-started] guide.
 
 <!-- Links -->
 
-[sighup-page]: https://sighup.io
 [velero-page]: https://velero.io
 [velero-node-agent-page]: https://velero.io/docs/v1.18/file-system-backup/
-[minio-page]: https://min.io/
-[terraform-page]: https://www.terraform.io/
-[skd-repo]: https://github.com/sighupio/distribution
+[csi-data-movement]: https://velero.io/docs/main/csi-snapshot-data-movement/
+[kfd-repo]: https://github.com/sighupio/distribution
 [furyctl-repo]: https://github.com/sighupio/furyctl
-[kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
-[velero-gcp-plugin-repo]: https://github.com/vmware-tanzu/velero-plugin-for-gcp
-[velero-aws-plugin-repo]: https://github.com/vmware-tanzu/velero-plugin-for-aws
-[velero-azure-plugin-repo]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure
-[velero-gcp-plugin-repo-permissions]: https://github.com/vmware-tanzu/velero-plugin-for-gcp#set-permissions-for-velero
-[skd-velero-gcp-example]: https://github.com/sighupio/module-dr/tree/main/examples/gcp-examples/main.tf
-[skd-velero-aws-example]: https://github.com/sighupio/module-dr/tree/main/examples/aws-examples/main.tf
-[skd-velero-azure-example]: https://github.com/sighupio/module-dr/tree/main/examples/azure-examples/main.tf
-[skd-velero-on-prem]: https://github.com/sighupio/module-dr/tree/main/katalog/velero/velero-on-prem
-[aws-docs-iam-roles]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
-[skd-docs]: https://docs.sighup.io/
-[compatibility-matrix]: https://github.com/sighupio/module-dr/blob/master/docs/COMPATIBILITY_MATRIX.md
-[etcd-backup-s3-link]: https://github.com/sighupio/module-dr/blob/master/katalog/etcd-backup-s3/README.md
-[etcd-backup-pvc-link]: https://github.com/sighupio/module-dr/blob/master/katalog/etcd-backup-pvc/README.md
+[kfd-docs]: https://docs.sighup.io/docs/distribution/
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesdr
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesdr
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesdr
+[getting-started]: https://docs.sighup.io/docs/getting-started/
+[compatibility-matrix]: https://github.com/sighupio/module-dr/blob/main/docs/COMPATIBILITY_MATRIX.md
+
 <!-- </SD-DOCS> -->
 
 <!-- <FOOTER> -->
 
 ## Contributing
 
-Before contributing, please read first the [Contributing Guidelines](docs/CONTRIBUTING.md).
+Before contributing, please read first the [Contributing Guidelines](https://github.com/sighupio/distribution/blob/main/docs/CONTRIBUTING.md).
 
 ### Reporting Issues
 
@@ -393,6 +124,6 @@ In case you experience any problem with the module, please [open a new issue](ht
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source and it's released under the following [LICENSE](LICENSE).
 
 <!-- </FOOTER> -->

--- a/katalog/etcd-backup-pvc/README.md
+++ b/katalog/etcd-backup-pvc/README.md
@@ -1,145 +1,17 @@
 # ETCD Backup PVC
 
-This package provides an automated solution for backing up ETCD data to a Persistent Volume Claim present in the cluster.
+<!-- <SD-DOCS> -->
 
 ## Overview
 
-This package creates a CronJob that:
+ETCD Backup PVC runs a Kubernetes CronJob that snapshots the cluster's etcd database and copies the snapshots to a pre-provisioned PersistentVolumeClaim using `rclone`, cleaning up old backups based on a configurable retention policy. The job runs on a control plane node, uses the host network, and is fault-tolerant: it queries the cluster for a healthy etcd node and snapshots one of them.
 
-1. Takes a snapshot of the ETCD database
-2. Copies the snapshot to a defined PersistentVolumeName
-3. Cleans up old backups based on a configurable retention policy
+## Deployment
 
-The job is scheduled to run on one of the available control plane nodes and uses `rclone` to manage the actual backup and its lifecycle.
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It applies to `OnPremises` (self-managed) clusters where you control etcd, and is selected automatically based on the `etcdBackup` configuration. See the [module documentation](../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-The job is fault-tolerant, as it tries to backup the available etcd nodes:
-even if one of the etcd nodes (if you're in a HA-setup) is failing,
-`etcd-backup-pvc` asks the cluster which nodes are healthy and spashots one of
-them.
+<!-- </SD-DOCS> -->
 
-> [!NOTE]
-> The job is configured to use the Host Network, as a consequence it cannot resolve service names internal to the cluster or connect to them via the internal Kubernetes network.
+## License
 
-## Requirements
-
-- A Kubernetes cluster with ETCD
-- Access to control plane nodes
-- A pre-provisioned PersistentVolumeClaim
-
-> [!NOTE]
-> By default we rely on `ClusterConfiguration` found inside the `kubeadm-config` ConfigMap to
-> extract the ETCD server endpoints. If you want to use a cluster that's not managed by
-> `kubeadm`, please make sure to remove the `kubeadm-config` volume, and pass the CronJob the
-> `ETCDCTL_ENDPOINTS` environment variable set accordingly.
-
-## Configuration
-
-### Default Configuration
-
-The package includes the following default configuration:
-
-- The backup runs on specified schedule (configurable)
-- Snapshots are stored in the format `<my-custom-prefix>YYYYMMDDHHMM.etcdb`, the prefix is configurable by the user, using `kustomize`.
-- Backups are uploaded to the configured PersistentVolumeClaim
-- Old backups are cleaned up based on the retention policy
-
-### Components
-
-- **CronJob**: Orchestrates the backup process
-- **ConfigMaps**:
-  - `etcd-backup-pvc-config`: Contains retention settings and the prefix to be used for the backup names
-  - `etcd-backup-pvc-certificates-location`: Contains ETCD connection parameters
-
-## Usage
-
-### Basic Installation
-
-1. Apply the package using kustomize:
-
-```bash
-kubectl apply -k /path/to/etcd-backup-pvc
-```
-
-### Customization
-
-To customize the package, create your own `kustomization.yaml` that references this package:
-
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - /path/to/etcd-backup-pvc
-
-# Override configurations as needed
-patches:
-  - patch: |-
-      apiVersion: batch/v1
-      kind: CronJob
-      metadata:
-        name: etcd-backup-pvc
-      spec:
-        schedule: "0 1 * * *"  # Run at 1:00 AM daily
-  - patch: |-
-      - op: replace
-        path: /spec/jobTemplate/spec/template/spec/volumes/2/persistentVolumeClaim/claimName
-        value: my-own-pvc
-    target:
-      group: batch
-      version: v1
-      kind: CronJob
-      name: etcd-backup-pvc
-
-# Override configmaps
-configMapGenerator:
-  - name: etcd-backup-pvc-config
-    behavior: replace # this is important, because a configMap is already defined with some defaults
-    literals:
-      - backup-prefix=my-custom-prefix-
-      - retention=30d  # Keep backups for 30 days
-```
-
-### Configuration Options
-
-#### Schedule
-
-You can modify the backup schedule using cron syntax:
-
-| Schedule | Description |
-|----------|-------------|
-| `0 1 * * *` | Daily at 1:00 AM |
-| `0 */6 * * *` | Every 6 hours |
-| `0 0 * * 0` | Weekly on Sunday at midnight |
-
-By default, it runs every day at 1AM.
-
-#### Target
-
-Backups are automatically saved at the root of the PVC volume. The name follows the following format: `<my-custom-prefix>YYYYMMDDHHMM.etcdb`.
-
-The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-pvc-config` ConfigMap. By default, it's set as `my-pvc-etcd-backup-`.
-
-#### Retention
-
-Specifies how long backups should be kept before automatic deletion (follows the rclone `--min-age` format):
-
-| Value | Description |
-|-------|-------------|
-| `10d` | 10 days |
-| `1w` | 1 week |
-| `3M` | 3 months |
-
-By default, it's set to `10d`.
-
-## Security Considerations
-
-- The CronJob runs with host network access to connect to the local ETCD instance
-- It mounts the ETCD certificates from the host to authenticate and container root access is thus required
-
-## Troubleshooting
-
-Check the job logs for detailed error messages:
-
-```bash
-kubectl logs -n kube-system job/etcd-backup-pvc-<job-id> --all-containers
-```
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/etcd-backup-s3/README.md
+++ b/katalog/etcd-backup-s3/README.md
@@ -1,146 +1,17 @@
 # ETCD Backup S3
 
-This package provides an automated solution for backing up ETCD data to an S3-compatible storage service using a Kubernetes CronJob.
+<!-- <SD-DOCS> -->
 
 ## Overview
 
-This package creates a CronJob that:
+ETCD Backup S3 runs a Kubernetes CronJob that snapshots the cluster's etcd database and uploads the snapshots to an S3-compatible storage target using `rclone`, cleaning up old backups based on a configurable retention policy. The job runs on a control plane node, uses the host network, and is fault-tolerant: it queries the cluster for a healthy etcd node and snapshots one of them.
 
-1. Takes a snapshot of the ETCD database
-2. Uploads the snapshot to an S3-compatible storage target
-3. Cleans up old backups based on a configurable retention policy
+## Deployment
 
-The job is scheduled to run on one of the available control plane nodes and uses `rclone` to manage the S3 uploads and lifecycle management.
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It applies to `OnPremises` (self-managed) clusters where you control etcd, and is selected automatically based on the `etcdBackup` configuration. See the [module documentation](../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-The job is fault-tolerant, as it tries to backup the available etcd nodes:
-even if one of the etcd nodes (if you're in a HA-setup) is failing,
-`etcd-backup-s3` asks the cluster which nodes are healthy and spashots one of
-them.
+<!-- </SD-DOCS> -->
 
-> [!NOTE]
-> The job is configured to use the Host Network, as a consequence it cannot resolve service names internal to the cluster or connect to them via the internal Kubernetes network.
+## License
 
-## Requirements
-
-- A Kubernetes cluster with ETCD
-- Access to control plane nodes
-- An S3-compatible storage target (like MinIO, AWS S3, etc.)
-- `rclone` configuration for your S3 service
-
-> [!NOTE]
-> By default we rely on `ClusterConfiguration` found inside the `kubeadm-config` ConfigMap to
-> extract the ETCD server endpoints. If you want to use a cluster that's not managed by
-> `kubeadm`, please make sure to remove the `kubeadm-config` volume, and pass the CronJob the
-> `ETCDCTL_ENDPOINTS` environment variable set accordingly.
-
-## Configuration
-
-### Default Configuration
-
-The package includes the following default configuration:
-
-- The backup runs on specified schedule (configurable)
-- Snapshots are stored in the format `<my-custom-prefix>YYYYMMDDHHMM.etcdb`, the prefix is configurable by the user, using `kustomize`.
-- Backups are uploaded to the configured S3 target
-- Old backups are cleaned up based on the retention policy
-
-### Components
-
-- **CronJob**: Orchestrates the backup process
-- **ConfigMaps**:
-  - `etcd-backup-s3-config`: Contains S3 target, retention settings and the backup name prefix
-  - `etcd-backup-s3-certificates-location`: Contains ETCD connection parameters
-- **Secret**:
-  - `etcd-backup-s3-rclone-conf`: Contains the rclone configuration
-
-## Usage
-
-### Basic Installation
-
-1. Create an `rclone.conf` file with your S3 credentials in the `rclone` directory
-2. Apply the package using kustomize:
-
-```bash
-kubectl apply -k /path/to/etcd-backup-s3
-```
-
-### Customization
-
-To customize the package, create your own `kustomization.yaml` that references this package:
-
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - /path/to/etcd-backup-s3
-
-# Override configurations as needed
-patches:
-  - patch: |-
-      apiVersion: batch/v1
-      kind: CronJob
-      metadata:
-        name: etcd-backup-s3
-      spec:
-        schedule: "0 1 * * *"  # Run at 1:00 AM daily
-
-# Override configmaps
-configMapGenerator:
-  - name: etcd-backup-s3-config
-    behavior: replace # this is important, because a configMap is already defined with some defaults
-    literals:
-      - backup-prefix=my-custom-prefix-
-      - target=s3:your-bucket-name/backups # `s3` must match with the section name in rclone.conf
-      - retention=30d  # Keep backups for 30 days
-```
-
-### Configuration Options
-
-#### Schedule
-
-You can modify the backup schedule using cron syntax:
-
-| Schedule | Description |
-|----------|-------------|
-| `0 1 * * *` | Daily at 1:00 AM |
-| `0 */6 * * *` | Every 6 hours |
-| `0 0 * * 0` | Weekly on Sunday at midnight |
-
-By default it runs every day at 1AM.
-
-#### Target
-
-The S3 target follows the rclone format: `provider:bucket-name/path`. By default it's: `minio:bucketname`.
-
-The name follows the following format: `<my-custom-prefix>YYYYMMDDHHMM.etcdb`.
-
-The prefix is configurable by setting the `backup-prefix` field inside the `etcd-backup-s3-config` ConfigMap. By default it's set to `my-s3-etcd-backup-`.
-
-The `provider` is defined in the `rclone.conf` file, name in the target must match the name of the section in the configuration file.
-
-#### Retention
-
-Specifies how long backups should be kept before automatic deletion (follows the rclone `--min-age` format):
-
-| Value | Description |
-|-------|-------------|
-| `10d` | 10 days |
-| `1w` | 1 week |
-| `3M` | 3 months |
-
-By default, it's set to `10d`.
-
-## Security Considerations
-
-- The CronJob runs with host network access to connect to the local ETCD instance
-- It mounts the ETCD certificates from the host to authenticate and container root access is thus required
-- The rclone configuration contains sensitive credentials and is stored as a Kubernetes Secret
-
-## Troubleshooting
-
-Check the job logs for detailed error messages:
-
-```bash
-kubectl logs -n kube-system job/etcd-backup-s3-<job-id> --all-containers
-```
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/velero/README.md
+++ b/katalog/velero/README.md
@@ -1,195 +1,28 @@
 # Velero
 
-![Velero Logo](../../docs/assets/velero.png)
-
-- [Velero](#velero)
-  - [Requirements](#requirements)
-  - [Server deployment](#server-deployment)
-    - [Velero on-premises](#velero-on-premises)
-    - [Velero on AWS](#velero-on-aws)
-    - [Velero on GCP](#velero-on-gcp)
-    - [Velero on Azure](#velero-on-azure)
-    - [Velero Node Agent](#velero-node-agent)
-    - [Velero schedule](#velero-schedule)
-
 <!-- <SD-DOCS> -->
 
-Velero *(formerly Heptio Ark)* gives you tool to back up and restore your Kubernetes cluster resources and persistent
-volumes. You can run Velero with a cloud provider or on-premises. Velero lets you:
+## Overview
 
-- Take backups of your cluster and restore in case of loss.
-- Migrate cluster resources to other clusters.
-- Replicate your production cluster to development and testing clusters.
+Velero *(formerly Heptio Ark)* backs up and restores Kubernetes cluster resources and persistent volumes. It lets you take backups of your cluster and restore them in case of loss, migrate cluster resources to other clusters, and replicate your production cluster to development and testing clusters. It can run with a cloud provider or on-premises. This package bundles the Velero server together with the components that support the different storage backends and providers.
 
-Velero consists of:
+## Upstream project
 
-- A server that runs on your cluster
-- A command-line client that runs locally
+This package is based on the upstream [Velero][velero-page].
 
-## Requirements
+## Deployment
 
-Velero requires to have already deployed the [prometheus-operator](https://github.com/coreos/prometheus-operator) CRDs
-as this feature deploys [a `ServiceMonitor` definition](velero-base/serviceMonitor.yaml). It can be deployed using the
-[skd-monitoring](https://github.com/sighupio/module-monitoring) SD core module.
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.dr.velero` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-## Server deployment
+<!-- Links -->
 
-Every velero deployment, does not matter if on-premises or in any of the supported cloud, can configure
-[schedules](#velero-schedule) to back up all cluster manifests and/or cluster persistence volumes.
-
-### Velero on-premises
-
-The [velero-on-prem](./velero-on-prem/) feature deploys a [MinIO](https://min.io/) instance in the same cluster as
-object storage backend that Velero can use to store backup data.
-
-*Example `kustomization.yaml` file*
-
-```yaml
-namespace: kube-system
-
-bases:
-  - vendor/katalog/dr/velero/velero-base
-  - vendor/katalog/dr/velero/velero-on-prem
-```
-
-### Velero on AWS
-
-The [AWS deployment alternative](./velero-aws) requires to have created `cloud-credentials` secret in the
-`kube-system` namespace.
-You can find a [terraform module](../../modules/aws-velero) designed to create all necessary cloud resources
-to make velero works in AWS.
-
-You can find and example terraform project using the [aws-velero](../../modules/aws-velero) terraform module
-[here](../../examples/aws-examples/main.tf)
-
-```bash
-$ cd examples/aws-example
-$ terraform init
-# omitted output
-$ terraform apply --var="my_cluster_name=kubernetes-cluster-and-velero"
-# omitted output
-$ terraform output -raw cloud_credentials > /tmp/cloud_credentials.config
-$ terraform output -raw volume_snapshot_location > /tmp/volume_snapshot_location.yaml
-$ terraform output -raw backup_storage_location > /tmp/backup_storage_location.yaml
-$ kubectl apply -f /tmp/cloud_credentials.config -n kube-system
-# omitted output
-$ kubectl apply -f /tmp/volume_snapshot_location.yaml -n kube-system
-# omitted output
-$ kubectl apply -f /tmp/backup_storage_location.yaml -n kube-system
-# omitted output
-```
-
-Then, you will be able to deploy the velero AWS deployment.
-
-*Example `kustomization.yaml` file*
-
-```yaml
-namespace: kube-system
-
-bases:
-  - vendor/katalog/dr/velero/velero-base
-  - vendor/katalog/dr/velero/velero-aws
-```
-
-More information about the [AWS Velero Plugin](https://github.com/vmware-tanzu/velero-plugin-for-aws)
-
-### Velero on GCP
-
-The [GCP deployment alternative](./velero-gcp) requires to have created `cloud-credentials` secret in the
-`kube-system` namespace.
-You can find a [terraform module](../../modules/gcp-velero) designed to create all necessary cloud resources
-to make velero works in GCP.
-
-Then, you will be able to deploy the velero GCP deployment.
-
-*Example `kustomization.yaml` file*
-
-```yaml
-namespace: kube-system
-
-bases:
-  - vendor/katalog/dr/velero/velero-base
-  - vendor/katalog/dr/velero/velero-gcp
-```
-
-More information about the [GCP Velero Plugin](https://github.com/vmware-tanzu/velero-plugin-for-gcp)
-
-### Velero on Azure
-
-The [Azure deployment alternative](./velero-azure) requires to have created `cloud-credentials` secret in the
-`kube-system` namespace.
-You can find a [terraform module](../../modules/azure-velero) designed to create all necessary cloud resources
-to make velero works in Azure.
-
-Then, you will be able to deploy the velero Azure deployment.
-
-*Example `kustomization.yaml` file*
-
-```yaml
-namespace: kube-system
-
-bases:
-  - vendor/katalog/dr/velero/velero-base
-  - vendor/katalog/dr/velero/velero-azure
-```
-
-More information about the [Azure Velero Plugin](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure)
-
-### Velero Node Agent
-
-> [!IMPORTANT]  
-> Velero Restic has been renamed to Velero Node Agent in v2.2.0
-
-Velero has support for backing up and restoring Kubernetes volumes using free open-source backup tools like restic and kopia.
-
-[velero-node-agent](./velero-node-agent) requires to have a velero deployment running in the cluster before deploy it.
-Velero Node Agent is not tied to be deployed on prem or on cloud. So feel free to deploy it with your prefered velero
-deployment.
-
-```yaml
-namespace: kube-system
-
-bases:
-  - vendor/katalog/dr/velero/velero-base
-  - vendor/katalog/dr/velero/velero-aws
-  - vendor/katalog/dr/velero/velero-node-agent
-```
-
-More information about [Velero Node Agent integration](https://velero.io/docs/v1.18/file-system-backup/)
-
-### Velero schedule
-
-This module contains a couple of useful [velero schedules](velero-schedules) to perform automatic backups of cluster manifests and/or
-persistence volumes.
-
-Feel free to deploy these schedules if fits in your business:
-
-```yaml
-namespace: kube-system
-
-bases:
-  - vendor/katalog/dr/velero/velero-base
-  - vendor/katalog/dr/velero/velero-aws
-  - vendor/katalog/dr/velero/velero-schedules
-```
-
-More information about [velero schedules](https://github.com/vmware-tanzu/velero/blob/master/site/docs/master/api-types/schedule.md)
-
-### Snapshot Controller
-
-The [`snapshot-controller`](./snapshot-controller/) module enables [CSI Snapshot Data Movement](https://velero.io/docs/main/csi-snapshot-data-movement/) support and is specifically designed to move **CSI snapshot data** to a backup storage location.
-
-It requires requires a **CSI driver** to be installed on the underlying infrastructure, as **Velero** will use it to perform the data movement.
-
-Example `kustomization.yaml` file
-
-```yaml
-namespace: kube-system
-
-bases:
-  - vendor/katalog/dr/velero/velero-base
-  - vendor/katalog/dr/velero/velero-on-prem
-  - vendor/katalog/dr/velero/snapshot-controller
-```
+[velero-page]: https://velero.io
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesdr
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesdr
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesdr
 
 <!-- </SD-DOCS> -->
+
+## License
+
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/velero/snapshot-controller/README.md
+++ b/katalog/velero/snapshot-controller/README.md
@@ -1,63 +1,25 @@
-# Snapshot Controller for Velero CSI Snapshot Data Movement
+# Snapshot Controller
 
-This component [`snapshot-controller`](../../katalog/velero/snapshot-controller/) has been added to allow the volumes data to be backed up to a pre-defined backup storage in a consistent manner, following the [CSI Snapshot Data Movement design](https://velero.io/docs/main/csi-snapshot-data-movement/).
+<!-- <SD-DOCS> -->
 
-## Image repository and tag
+## Overview
 
-- Snapshot Controller image: `registry.k8s.io/sig-storage/snapshot-controller:v8.2.0`
-- Snapshot Controller repository:
-[github.com/kubernetes-csi/external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter).
+The Snapshot Controller enables [CSI Snapshot Data Movement][csi-data-movement] support, allowing Velero to move CSI snapshot data to a backup storage location in a consistent manner. It requires a CSI driver capable of volume snapshots at the v1 API level installed on the underlying infrastructure.
 
-## Requirements
+## Upstream project
 
-This deployment of the `snapshot-controller`, in order to enable **CSI Snapshot Data Movement* support, requires that the cluster meets the following prerequisites:
-
-- it has a running **CSI Driver** capable of support volume snapshots at the [v1 API level](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/).
-- supports the [Kubernetes MountPropagation](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation) feature.
-
-As default behaviour, a `VolumeSnapshotClass` can be created for a particular driver, adding a label on it to indicate that it is the default **VolumeSnapshotClass** for that driver:
-
-Example `VolumeSnapshotClass`:
-```yaml
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshotClass
-metadata:
-  name: velero-snapclass
-  labels:
-    velero.io/csi-volumesnapshot-class: "true"
-driver: hostpath.csi.k8s.io
-deletionPolicy: Retain
-```
-
-In this way, the CSI snapshot will be applied for all the volumes backed by the **CSI Driver**.
-
-Example of `PersistentVolumeClaim` that uses the **CSI Driver storage class**:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: example-pvc
-  namespace: example-namespace
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: csi-hostpath-sc # CSI Driver StorageClass
-  resources:
-    requests:
-      storage: 100Mi
-```
-
-Other implementation choices are available for implementing the CSI snapshot, consider to take a look at the [documentation](https://velero.io/docs/main/csi/).
+This package is based on the upstream [CSI external-snapshotter][external-snapshotter].
 
 ## Deployment
 
-You can deploy the `snapshot-controller` enabling [CSI Data Movement support](https://velero.io/docs/main/csi-snapshot-data-movement/) by running the following command from the root of the [`snapshot-controller` module](../snapshot-controller/):
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically when CSI Snapshot Data Movement is enabled. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-```bash
-$ kustomize build | kubectl apply -f -
-# omitted output
-```
+<!-- Links -->
+
+[csi-data-movement]: https://velero.io/docs/main/csi-snapshot-data-movement/
+[external-snapshotter]: https://github.com/kubernetes-csi/external-snapshotter
+
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/velero/velero-aws/README.md
+++ b/katalog/velero/velero-aws/README.md
@@ -1,84 +1,24 @@
 # Velero AWS
 
-This Velero deployment is ready to be deployed in any AWS cluster as it includes the
-[AWS Velero plugin](https://github.com/vmware-tanzu/velero-plugin-for-aws/tree/v1.11.1).
+<!-- <SD-DOCS> -->
 
-## Image repository and tag
+## Overview
 
-- Velero AWS Plugin image: `velero/velero-plugin-for-aws:v1.11.1`
-- Velero AWS Plugin repository:
-[https://github.com/vmware-tanzu/velero-plugin-for-aws](https://github.com/vmware-tanzu/velero-plugin-for-aws).
+Velero AWS deploys Velero together with the AWS plugin so that backups are stored in an S3 bucket and volume snapshots use AWS EBS. It builds on top of `velero-base` and expects the `cloud-credentials` secret and a `default` BackupStorageLocation to be available.
 
+## Upstream project
 
-## Requirements
-
-This deployment requires to have previously created the following resources:
-
-- `cloud-credentials` Kubernetes Secret in the `kube-system` namespace.
-- `default` BackupStorageLocation in the `kube-system` namespace.
-
-
-### Cloud Credentials
-
-This SIGHUP Distribution Core module contains [a terraform module](../../../modules/aws-velero) designed to generate every file needed
-by this deployment including the Cloud Credentials file.
-
-```bash
-$ terraform init
-# omitted output
-$ terraform apply
-# omitted output
-$ terraform output -raw cloud_credentials > /tmp/cloud_credentials.yaml
-# omitted output
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/cloud_credentials.yaml -n kube-system
-secret/cloud-credentials created
-```
-
-
-### *Default* BackupStorageLocation
-
-As this deployment creates a [`Schedule`](../velero-base/schedule.yaml) it's required to have a `BackupStorageLocation`
-named `default` to automate the *manifests* backup creation.
-
-Again, the terraform module provided with this deployment creates it as terraform output:
-
-```bash
-$ terraform init
-$ terraform apply
-$ terraform output -raw backup_storage_location > /tmp/backup_storage_location.yaml
-$ cat /tmp/backup_storage_location.yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-spec:
-  provider: velero.io/aws
-  objectStorage:
-    bucket: bucket-name-storing-kubernetes-manifests
-  config:
-    region: aws-region-10
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/backup_storage_location.yaml -n kube-system
-# omitted output
-```
+This package is based on the upstream [Velero plugin for AWS][plugin].
 
 ## Deployment
 
-You can deploy Velero AWS by running the following command in the root of this project:
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically when the chosen provider uses an AWS S3 backend. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-```bash
-$ kustomize build | kubectl apply -f -
-# omitted output
-```
+<!-- Links -->
+
+[plugin]: https://github.com/vmware-tanzu/velero-plugin-for-aws
+
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/velero/velero-azure/README.md
+++ b/katalog/velero/velero-azure/README.md
@@ -1,85 +1,24 @@
 # Velero Azure
 
-This Velero deployment is ready to be deployed in any Azure cluster as it includes the
-[Azure Velero plugin](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/tree/v1.11.1).
+<!-- <SD-DOCS> -->
 
-## Image repository and tag
+## Overview
 
-- Velero Azure Plugin image: `velero/velero-plugin-for-microsoft-azure:v1.11.1`
-- Velero Azure Plugin repository:
-[https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure).
+Velero Azure deploys Velero together with the Azure plugin so that backups are stored in an Azure Storage container and volume snapshots use Azure managed disks. It builds on top of `velero-base` and expects the `cloud-credentials` secret and a `default` BackupStorageLocation to be available.
 
+## Upstream project
 
-## Requirements
-
-This deployment requires to have previously created the following resources:
-
-- `cloud-credentials` Kubernetes Secret in the `kube-system` namespace.
-- `default` BackupStorageLocation in the `kube-system` namespace.
-
-
-### Cloud Credentials
-
-This SIGHUP Distribution Core module contains [a terraform module](../../../modules/azure-velero) designed to generate every file needed
-by this deployment including the Cloud Credentials file.
-
-```bash
-$ terraform init
-# omitted output
-$ terraform apply
-# omitted output
-$ terraform output -raw cloud_credentials > /tmp/cloud_credentials.yaml
-# omitted output
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/cloud_credentials.yaml -n kube-system
-secret/cloud-credentials created
-```
-
-
-### *Default* BackupStorageLocation
-
-As this deployment creates a [`Schedule`](../velero-base/schedule.yaml) it's required to have a `BackupStorageLocation`
-named `default` to automate the *manifests* backup creation.
-
-Again, the terraform module provided with this deployment creates it as terraform output:
-
-```bash
-$ terraform init
-$ terraform apply
-$ terraform output -raw backup_storage_location > /tmp/backup_storage_location.yaml
-$ cat /tmp/backup_storage_location.yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-spec:
-  provider: velero.io/azure
-  objectStorage:
-    bucket: bucket-name-storing-kubernetes-manifests
-  config:
-    resourceGroup: 123-name
-    storageAccount: 123-name
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/backup_storage_location.yaml -n kube-system
-# omitted output
-```
+This package is based on the upstream [Velero plugin for Microsoft Azure][plugin].
 
 ## Deployment
 
-You can deploy Velero Azure by running the following command in the root of this project:
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically when the chosen provider uses an Azure backend. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-```bash
-$ kustomize build | kubectl apply -f -
-# omitted output
-```
+<!-- Links -->
+
+[plugin]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure
+
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/velero/velero-base/README.md
+++ b/katalog/velero/velero-base/README.md
@@ -1,23 +1,17 @@
 # Velero Base
 
-This directory contains common components needed to deploy Velero.
+<!-- <SD-DOCS> -->
 
-## Common components
+## Overview
 
-- [CRDs](./crds.yaml)
-- [Base Velero deployment](./deployment.yaml)
-- [RBAC](./rbac.yaml)
-- [Manifest backup Schedule definition](./schedule.yaml)
-- [Velero metrics service](./service.yaml)
-- [Velero ServiceMonitor](./serviceMonitor.yaml)
+Velero Base contains the common Velero components (CRDs, base deployment, RBAC, manifest backup schedule and the metrics service and ServiceMonitor) shared by every backend. It does not provide a working backup setup on its own; the backend-specific packages build on top of it.
 
-## Important
+## Deployment
 
-This directory does not provide any functionality by itself. Please refer to the different Velero deployment options:
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically based on the chosen backend and provider. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-- [Velero On Prem](../velero-on-prem/README.md)
-- [Velero AWS](../velero-aws/README.md)
-- [Velero GCP](../velero-gcp/README.md)
-- [Velero Azure](../velero-azure/README.md)
+<!-- </SD-DOCS> -->
 
-These deployments uses this base to deploy velero configured for each cloud provider.
+## License
+
+For license details please see [LICENSE](../../../LICENSE)

--- a/katalog/velero/velero-gcp/README.md
+++ b/katalog/velero/velero-gcp/README.md
@@ -1,81 +1,24 @@
 # Velero GCP
 
-This Velero deployment is ready to be deployed in any GCP cluster as it includes the
-[GCP Velero plugin](https://github.com/vmware-tanzu/velero-plugin-for-gcp/tree/v1.11.1).
+<!-- <SD-DOCS> -->
 
-## Image repository and tag
+## Overview
 
-- Velero GCP Plugin image: `velero/velero-plugin-for-gcp:v1.11.1`
-- Velero GCP Plugin repository:
-[https://github.com/vmware-tanzu/velero-plugin-for-gcp](https://github.com/vmware-tanzu/velero-plugin-for-gcp).
+Velero GCP deploys Velero together with the GCP plugin so that backups are stored in a GCS bucket and volume snapshots use GCP persistent disks. It builds on top of `velero-base` and expects the `cloud-credentials` secret and a `default` BackupStorageLocation to be available.
 
+## Upstream project
 
-## Requirements
-
-This deployment requires to have previously created the following resources:
-
-- `cloud-credentials` Kubernetes Secret in the `kube-system` namespace.
-- `default` BackupStorageLocation in the `kube-system` namespace.
-
-
-### Cloud Credentials
-
-This SIGHUP Distribution Core module contains [a terraform module](../../../modules/gcp-velero) designed to generate every file needed
-by this deployment including the Cloud Credentials file.
-
-```bash
-$ terraform init
-$ terraform apply
-$ terraform output -raw cloud_credentials > /tmp/cloud_credentials.yaml
-# omitted output
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/cloud_credentials.yaml -n kube-system
-secret/cloud-credentials created
-```
-
-
-### *Default* BackupStorageLocation
-
-As this deployment creates a [`Schedule`](../velero-base/schedule.yaml) it's required to have a `BackupStorageLocation`
-named `default` to automate the *manifests* backup creation.
-
-Again, the terraform module provided with this deployment creates it as terraform output:
-
-```bash
-$ terraform init
-$ terraform apply
-$ terraform output -raw backup_storage_location > /tmp/backup_storage_location.yaml
-$ cat /tmp/backup_storage_location.yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-spec:
-  provider: velero.io/gcp
-  objectStorage:
-    bucket: bucket-name-storing-kubernetes-manifests
-    prefix: velero
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/backup_storage_location.yaml -n kube-system
-# omitted output
-```
+This package is based on the upstream [Velero plugin for GCP][plugin].
 
 ## Deployment
 
-You can deploy Velero GCP by running the following command in the root of this project:
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically when the chosen backend is `gcs`. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-```bash
-$ kustomize build | kubectl apply -f -
-# omitted output
-```
+<!-- Links -->
+
+[plugin]: https://github.com/vmware-tanzu/velero-plugin-for-gcp
+
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/velero/velero-node-agent/README.md
+++ b/katalog/velero/velero-node-agent/README.md
@@ -1,34 +1,26 @@
 # Velero Node Agent
 
-Velero supports backing up and restoring Kubernetes volumes attached to pods from the file system of the modules.
-The data movement is fulfilled by using [restic](https://github.com/restic/restic) and [Kopia](https://github.com/kopia/kopia), both are Open Source backup tools.
-This support is considered beta quality due to a list of [limitations](https://velero.io/docs/v1.12/file-system-backup/#limitations).
+<!-- <SD-DOCS> -->
 
+## Overview
 
-## Image repository and tag
+Velero Node Agent backs up and restores Kubernetes volumes attached to pods from the node file system, using the open-source backup tools [restic][restic] and [Kopia][kopia]. It requires a running Velero instance and is not tied to any specific backend.
 
-- Velero Node Agent image: `velero/velero:v1.16.2`
-- Velero Node Agent repository: [https://github.com/vmware-tanzu/velero](https://github.com/vmware-tanzu/velero).
+## Upstream project
 
-
-## Requirements
-
-This deployment requires to have previously deployed a velero instance. Choose one option:
-
-- [velero on premises](../velero-on-prem)
-- [velero AWS](../velero-aws)
-- [velero GCP](../velero-gcp)
-- [velero Azure](../velero-azure)
-
+This package is based on the upstream [Velero][velero-page] file system backup feature.
 
 ## Deployment
 
-You can deploy Velero AWS by running the following command in the root of this project:
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically when volume backups are enabled. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-```bash
-$ kustomize build | kubectl apply -f -
-# omitted output
-```
+<!-- Links -->
+
+[velero-page]: https://velero.io/docs/v1.18/file-system-backup/
+[restic]: https://github.com/restic/restic
+[kopia]: https://github.com/kopia/kopia
+
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/velero/velero-on-prem/README.md
+++ b/katalog/velero/velero-on-prem/README.md
@@ -1,33 +1,24 @@
 # Velero on Premises
 
-This Velero deployment is ready to be deployed in any Kubernetes cluster as it includes a MinIO instance compatible with
-the [AWS Velero plugin](https://github.com/vmware-tanzu/velero-plugin-for-aws/tree/v1.11.1).
+<!-- <SD-DOCS> -->
 
-## Image repository and tag
+## Overview
 
-- Velero AWS Plugin image: `velero/velero-plugin-for-aws:v1.11.1`
-- Velero AWS Plugin repository:
-[https://github.com/vmware-tanzu/velero-plugin-for-aws](https://github.com/vmware-tanzu/velero-plugin-for-aws).
-- MinIO image: `minio/minio:RELEASE.2025-02-28T09-55-16Z`
-- MinIO client image: `minio/mc:RELEASE.2025-02-21T16-00-46Z`
-- MinIO repository: [https://github.com/minio/minio](https://github.com/minio/minio)
+Velero on Premises deploys Velero with an in-cluster [MinIO][minio-page] instance as the S3-compatible object storage backend, using the AWS-compatible Velero plugin. It is intended for clusters that don't have access to a cloud provider's object storage. Note that the MinIO server runs in the same cluster that is being backed up.
 
+## Upstream project
+
+This package is based on the upstream [MinIO][minio-page] object storage server.
 
 ## Deployment
 
-You can deploy Velero AWS by running the following command in the root of this project:
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically when the chosen backend is `minio`. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-```bash
-$ kustomize build | kubectl apply -f -
-# omitted output
-```
+<!-- Links -->
 
-### Important Notes
+[minio-page]: https://min.io/
 
-The deployment order is managed by an `initContainer` that waits for a set of conditions. In this case, velero deployment
-waits for MinIO instance to be fully configured and ready.
-
-You can see it in [plugin-patch.yaml](./plugin-patch.yaml) and [minio/init-job.yaml](minio/init-job.yaml).
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/velero/velero-schedules/README.md
+++ b/katalog/velero/velero-schedules/README.md
@@ -1,103 +1,16 @@
 # Velero Schedules
 
-This directory contains common velero resources, schedules.
+<!-- <SD-DOCS> -->
 
-## Common resources
+## Overview
 
-- [Full Backup Schedule](./full.yaml)
-- [Manifests Only Schedule](./manifests.yaml)
+Velero Schedules provides a set of ready-to-use Velero `Schedule` resources to perform automatic backups: a full backup (cluster manifests and persistent volumes) and a manifests-only backup. The full schedule requires a `default` VolumeSnapshotLocation and the manifests schedule requires a `default` BackupStorageLocation, both of which are provisioned by the module for the chosen backend.
 
-## Important
+## Deployment
 
-This directory does not provide any functionality by itself. Please refer to the different Velero deployment
-options:
+This package is deployed as part of **Disaster Recovery Module** when you create a cluster with `furyctl`. It is an internal building block selected automatically based on the configured schedules. See the [module documentation](../../../README.md) to learn how the Disaster Recovery Module is installed and configured.
 
-- [Velero AWS](../velero-aws/README.md)
-- [Velero GCP](../velero-gcp/README.md)
-- [Velero Azure](../velero-azure/README.md)
-- [Velero on prem](../velero-on-prem/README.md)
-
-These deployments can use this base to deploy pre-configure velero schedules.
-
-### Requirement
-
-The `full` backup Schedule requires to have defined:
-
-- `default` VolumeSnapshotLocation in the `kube-system` namespace.
-
-The `manifest` backup Schedule requires to have defined:
-
-- `default` BackupStorageLocation in the `kube-system` namespace.
-
-### *Default* VolumeSnapshotLocation
-
-As this base creates a [`Schedule`](./full.yaml) it's required to have a `VolumeSnapshotLocation`
-named `default` to automate the *full* backup creation.
-
-This module provides a set of terraform modules ([aws](../../../modules/aws-velero), [gcp](../../../modules/gcp-velero)
-and [azure](../../../modules/azure-velero)) that creates it as terraform output:
-
-
-*Example GCP VolumeSnapshotLocation*
-
-```bash
-$ terraform init
-$ terraform apply
-$ terraform output -raw volume_snapshot_location > /tmp/volume_snapshot_location.yaml
-$ cat /tmp/volume_snapshot_location.yaml
-apiVersion: velero.io/v1
-kind: VolumeSnapshotLocation
-metadata:
-  name: default
-spec:
-  provider: velero.io/gcp
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/volume_snapshot_location.yaml -n kube-system
-# omitted output
-```
-
-### *Default* BackupStorageLocation
-
-As this base creates a [`Schedule`](./manifests.yaml) it's required to have a `BackupStorageLocation`
-named `default` to automate the *manifests* backup creation.
-
-This module provides a set of terraform modules ([aws](../../../modules/aws-velero), [gcp](../../../modules/gcp-velero)
-and [azure](../../../modules/azure-velero)) that creates it as terraform output:
-
-
-*Example GCP BackupStorageLocation*
-
-```bash
-$ terraform init
-# omitted output
-$ terraform apply
-# omitted output
-$ terraform output -raw backup_storage_location > /tmp/backup_storage_location.yaml
-# omitted output
-$ cat /tmp/backup_storage_location.yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-spec:
-  provider: velero.io/gcp
-  objectStorage:
-    bucket: my-gcs-velero-bucket
-    prefix: velero
-```
-
-Then you are ready to apply this file in the `kube-system` namespace:
-
-```bash
-$ kubectl apply -f /tmp/backup_storage_location.yaml -n kube-system
-# omitted output
-```
-
-If you choose to deploy the [velero on prem package](../velero-on-prem), this resource is preconfigured in the cluster.
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -2,7 +2,8 @@
 
 **This Terraform module generates the AWS cloud resources (S3 and IAM) required by Velero to back up Kubernetes objects and trigger volume snapshots.**
 
-> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
+> [!NOTE]
+> This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
 ## Requirements
 

--- a/modules/aws-velero/README.md
+++ b/modules/aws-velero/README.md
@@ -1,6 +1,8 @@
 # AWS Velero
 
-This terraform module provides an easy way to generate Velero required cloud resources (S3 and IAM) to backup Kubernetes objects and trigger volume snapshots.
+**This Terraform module generates the AWS cloud resources (S3 and IAM) required by Velero to back up Kubernetes objects and trigger volume snapshots.**
+
+> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
 ## Requirements
 
@@ -44,34 +46,3 @@ This terraform module provides an easy way to generate Velero required cloud res
 | cloud\_credentials         | Velero required file with credentials   |
 | service\_account           | Velero ServiceAccount                   |
 | volume\_snapshot\_location | Velero Cloud VolumeSnapshotLocation CRD |
-
-## Usage
-
-```hcl
-module "velero" {
-  source             = "../vendor/modules/aws-velero"
-  backup_bucket_name = "my-cluster-staging-velero"
-  tags               = {
-    "my-key": "my-value"
-  }
-}
-```
-
-To use IAM Roles for Service Accounts (IRSA):
-
-```hcl
-data "aws_eks_cluster" "this" {
-  name = "my-cluster-staging"
-}
-
-module "velero" {
-  source             = "../vendor/modules/aws-velero"
-  backup_bucket_name = "my-cluster-staging-velero"
-  oidc_provider_url  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
-  tags               = {
-    "my-key": "my-value"
-  }
-}
-```
-
-For more information about IAM Roles for Service Accounts to inject AWS credentials inside Velero's pods, click [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

--- a/modules/azure-velero/README.md
+++ b/modules/azure-velero/README.md
@@ -1,9 +1,10 @@
 # Azure Velero
 
-This terraform module provides an easy way to generate Velero required cloud resources (Object Storage and Credentials)
-to backup Kubernetes objects and trigger volume snapshots.
+**This Terraform module generates the Azure cloud resources (Object Storage and credentials) required by Velero to back up Kubernetes objects and trigger volume snapshots.**
 
-## Provider
+> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
+
+## Providers
 
 This module is compatible with `azurerm` terraform provider version:
 [`1.44.0`](https://github.com/terraform-providers/terraform-provider-azurerm/tree/v1.44.0)
@@ -25,23 +26,3 @@ This module is compatible with `azurerm` terraform provider version:
 | backup\_storage\_location  | Velero Cloud BackupStorageLocation CRD  |
 | cloud\_credentials         | Velero required file with credentials   |
 | volume\_snapshot\_location | Velero Cloud VolumeSnapshotLocation CRD |
-
-## Usage
-
-```hcl
-module "velero" {
-  source                     = "../vendor/modules/azure-velero"
-  backup_bucket_name         = "sighup-production-cluster-backup"
-  aks_resource_group_name    = "XXX"
-  velero_resource_group_name = "XXX"
-  tags                       = {
-    "my-key": "my-value"
-  }
-}
-```
-
-## Links
-
-- [https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.0/backupstoragelocation.md](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.0/backupstoragelocation.md)
-- [https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.0/volumesnapshotlocation.md](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/v1.2.0/volumesnapshotlocation.md)
-- [https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/tree/v1.2.0#create-azure-storage-account-and-blob-container](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/tree/v1.2.0#create-azure-storage-account-and-blob-container)

--- a/modules/azure-velero/README.md
+++ b/modules/azure-velero/README.md
@@ -2,7 +2,8 @@
 
 **This Terraform module generates the Azure cloud resources (Object Storage and credentials) required by Velero to back up Kubernetes objects and trigger volume snapshots.**
 
-> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
+> [!NOTE]
+> This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
 ## Providers
 

--- a/modules/gcp-velero/README.md
+++ b/modules/gcp-velero/README.md
@@ -2,7 +2,8 @@
 
 **This Terraform module generates the GCP cloud resources (Bucket and credentials) required by Velero to back up Kubernetes objects and trigger volume snapshots.**
 
-> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
+> [!NOTE]
+> This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
 ## Inputs
 

--- a/modules/gcp-velero/README.md
+++ b/modules/gcp-velero/README.md
@@ -1,7 +1,8 @@
 # GCP Velero
 
-This terraform module provides an easy way to generate Velero required cloud resources (Bucket and Credentials)
-to backup Kubernetes objects and trigger volume snapshots.
+**This Terraform module generates the GCP cloud resources (Bucket and credentials) required by Velero to back up Kubernetes objects and trigger volume snapshots.**
+
+> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
 ## Inputs
 
@@ -13,7 +14,6 @@ to backup Kubernetes objects and trigger volume snapshots.
 | gcp_custom_role_name     | Name of the gcp custom role to assign to the gcp service account              | `string`      | `"velero_role"` | yes      |
 | workload_identity        | Flag to specify if velero should use workload identity instead of credentials | `bool`        | `false`         | yes      |
 | tags                     | Custom tags to apply to resources                                             | `map(string)` | `{}`            | no       |
-
 
 ## Outputs
 
@@ -38,38 +38,3 @@ The presence of some outputs is conditional to the presence of `workload_identit
 | `remove_restic_credentials_patch`  | :x:                | :white_check_mark: |
 
 To find out more about workload identity go to the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identitys).
-
-## Usage
-
-Without workload identity:
-
-```hcl
-module "velero" {
-  source             = "../vendor/modules/gcp-velero"
-  backup_bucket_name = "my-cluster-staging-velero"
-  project            = "sighup-staging"
-  tags               = {
-    "my-key": "my-value"
-  }
-}
-```
-
-To enable workload identity:
-
-```hcl
-module "velero" {
-  source             = "../vendor/modules/gcp-velero"
-  backup_bucket_name = "my-cluster-staging-velero"
-  project            = "sighup-staging"
-  workload_identity  = true
-  tags               = {
-    "my-key": "my-value"
-  }
-}
-```
-
-## Links
-
-- [https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.0/backupstoragelocation.md](https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.0/backupstoragelocation.md)
-- [https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.0/volumesnapshotlocation.md](https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.0/volumesnapshotlocation.md)
-- [https://github.com/vmware-tanzu/velero-plugin-for-aws/tree/v1.2.0#setup](https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/v1.2.0/volumesnapshotlocation.md)


### PR DESCRIPTION
### Summary 💡

This PR replicates the documentation refactor defined in `module-aws` (#104) on this module: the docs are now furyctl/SD-centric and the legacy `Furyfile.yml` + `furyctl legacy vendor` + `kustomize build | kubectl apply` workflow has been removed.

Relates: sighupio/module-aws#104

### Description 📝

- **`README.md` (SD-DOCS block)**: removed the entire legacy per-provider deployment flow (Furyfile, vendor, kustomize/kubectl, terraform instantiation, prerequisites). New `Usage` section explains the module is deployed automatically by `furyctl`, with a type-driven `### Configuration` (the `type` field enables DR: `none`, or `eks` on EKSCluster / `on-premises` on KFDDistribution and OnPremises; `velero.backend` selects `minio`/`externalEndpoint`/`gcs`).
- **`katalog/*/README.md`**: rewritten to the shared template. Only the top-level `velero` package maps to a furyctl field (`spec.distribution.modules.dr.velero`); the velero sub-packages (aws/gcp/azure/on-prem/base/node-agent/schedules, snapshot-controller) are documented as internal building blocks selected automatically; `etcd-backup-s3`/`etcd-backup-pvc` documented as OnPremises-only.
- **`modules/*/README.md`** (aws/azure/gcp-velero): added the SD-managed note, dropped the standalone instantiation examples, kept the terraform-docs tables.

### Breaking Changes 💔

None, documentation only.

### Tests performed 🧪

- [x] No `Furyfile` / `furyctl legacy vendor` / `kustomize build | kubectl apply` references left in the `SD-DOCS` blocks
- [x] `furyctl.yaml` fields verified against the v1alpha2 schema (`type` per cluster kind, `velero.backend` enum, `etcdBackup` only on OnPremises)
- [x] Visual review of the GitHub markdown rendering

### Future work 🔧

- Replicate the same template on the remaining modules.